### PR TITLE
Add attempts property for retry attempt info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When the connection fails with one of `ECONNRESET`, `ENOTFOUND`, `ESOCKETTIMEDOU
 
 ## Usage
 
-Request-retry is a drop-in replacement for [request](https://github.com/mikeal/request) but adds two new options `maxAttempts` and `retryDelay`.
+Request-retry is a drop-in replacement for [request](https://github.com/mikeal/request) but adds two new options `maxAttempts` and `retryDelay`. It also adds one property to the response, `attempts`.
 
 ```javascript
 var request = require('requestretry');
@@ -21,6 +21,9 @@ request({
   retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
 }, function(err, response, body){
   // this callback will only be called when the request succeeded or after maxAttempts or on error
+  if (response) {
+    console.log('The number of request attempts: ' + response.attempts);
+  }
 });
 ```
 
@@ -62,7 +65,6 @@ var request = require('requestretry').request.defaults({my: options});
 ## Todo
 
 - Tests
-- Use an EventEmitter to notify retries
 
 ## [Changelog](CHANGELOG.md)
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var DEFAULTS = {
 function Request(options, f, maxAttempts, retryDelay) {
   this.maxAttempts = maxAttempts;
   this.retryDelay = retryDelay;
+  this.attempts = 0;
 
   /**
    * Option object
@@ -42,9 +43,13 @@ Request.request = request;
 
 Request.prototype._tryUntilFail = function () {
   this.maxAttempts--;
+  this.attempts++;
 
   this._req = Request.request(this.options, function (err, response, body) {
-    if (this.retryStrategy(err, response) && this.maxAttempts >= 0) {
+    if (response) {
+      response.attempts = this.attempts;
+    }
+    if (this.retryStrategy(err, response) && this.maxAttempts > 0) {
       this._timeout = setTimeout(this._tryUntilFail.bind(this), this.retryDelay);
       return;
     }

--- a/test/abort.test.js
+++ b/test/abort.test.js
@@ -6,7 +6,7 @@ var t = require('chai').assert;
 describe('Request-retry', function () {
   it('should return a RequestRetry handler object with a abort method', function (done) {
     var o = request({
-      url: 'http://filltext.com/?rows=1&delay=10', // wait for 4s
+      url: 'http://filltext.com/?rows=1&delay=10', // wait for 10s
       json: true
     }, function (err) {
       t.strictEqual(err.toString(), 'Error: Aborted');

--- a/test/attempts.test.js
+++ b/test/attempts.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var request = require('../');
+var t = require('chai').assert;
+
+describe('Request attempts', function () {
+  it('should show 1 attempt after a successful call', function (done) {
+    request({
+      url: 'http://www.filltext.com/?rows=1', // return 1 row of data
+    }, function (err, response, body) {
+      t.strictEqual(response.statusCode, 200);
+      t.strictEqual(response.attempts, 1);
+      done();
+    });
+  });
+
+  it('should show 3 attempts after some retries', function (done) {
+    request({
+      url: 'http://www.filltext.com/?rows=1&err=500', // return a 500 status
+      maxAttempts: 3,
+      retryDelay: 100
+    }, function (err, response, body) {
+      t.strictEqual(response.statusCode, 500);
+      t.strictEqual(response.attempts, 3);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This is a fix for https://github.com/FGRibreau/node-request-retry/issues/12.  I did not do this with the EventEmitter but through a property, as that also made sense to me as a solution.  Hope you feel the same way!

I also added a test for it, and fixed maxAttempts being off by one as shown by the tests.
