### PR TITLE
Incremental retry delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Install with [npm](https://npmjs.org/package/requestretry).
 
     npm install --save requestretry
 
+## How to use an incremental retry pattern
+ - If a retryIncrement and retryMaxDelay options are specified, the delay between attempts will be:
+```
+retryDelay + (retryIncrement * (attemptIndex - 1))
+```
+ - If retryMaxDelay is > 0, the delay between attempts will be capped at retryMaxDelay 
+
 ## How to define your own retry strategy
 
 ```

--- a/calculators/IncrementTimesAttemptDelayCalculator.js
+++ b/calculators/IncrementTimesAttemptDelayCalculator.js
@@ -1,0 +1,18 @@
+'use strict';
+module.exports = function IncrementTimesAttemptDelayCalculator(retryDelay, retryIncrement, attempts, retryMaxDelay) {
+  /**
+   * if retryIncrement is specified the delay will be retryDelay + (retryIncrement*attemptIndex-1)
+   * if retryMaxDelay is > 0, the delay between attempts will be capped at retryMaxDelay 
+   * @param  {Number} retryMaxDelay
+   * @param  {Number} retryIncrement
+   * @param  {Number} attempts	the rank of that attempt 
+   * @param  {Number} retryMaxDelay
+   * @return {Number} the delay  
+   */
+    var delay = retryDelay + (retryIncrement * (attempts -1 ));
+  	if(retryMaxDelay > 0 && delay > retryMaxDelay) {
+    	delay = retryMaxDelay;
+  	}
+  	return delay; 
+
+};

--- a/calculators/index.js
+++ b/calculators/index.js
@@ -1,0 +1,5 @@
+'use strict';
+var calculators = module.exports;
+
+calculators.IncrementTimesAttemptDelayCalculator = require('./IncrementTimesAttemptDelayCalculator');
+

--- a/test/calculators.test.js
+++ b/test/calculators.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var request = require('../');
+var t = require('chai').assert;
+
+describe('Delay Calculators', function () {
+  it('should return delay on first attempt', function () {
+    t.strictEqual(5, request.Calculators.IncrementTimesAttemptDelayCalculator(5, 2, 1, 10));
+  });
+  it('should return delay + retryIncrement on second attempt', function () {
+    t.strictEqual(7, request.Calculators.IncrementTimesAttemptDelayCalculator(5, 2, 2, 10));
+  });
+  it('should return delay + 2*retryIncrement on third attempt', function () {
+    t.strictEqual(9, request.Calculators.IncrementTimesAttemptDelayCalculator(5, 2, 3, 10));
+  });
+  it('should return cap to retryMaxDelay on fourth attempt', function () {
+    t.strictEqual(10, request.Calculators.IncrementTimesAttemptDelayCalculator(5, 2, 4, 10));
+  });
+});


### PR DESCRIPTION
Allow to specify an incremental retry pattern as the number of attempts grows.
. If a retryIncrement and retryMaxDelay options are specified, the delay between attempts will be:
retryDelay + (retryIncrement * (attemptIndex - 1))
. If retryMaxDelay is > 0, the delay between attempts will be capped at retryMaxDelay
