### PR TITLE
Added support for body-dependent retry strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Install with [npm](https://npmjs.org/package/requestretry).
  * @param  {Object} response
  * @return {Boolean} true if the request should be retried
  */
-function myRetryStrategy(err, response){
+function myRetryStrategy(err, response, body){
   // retry the request if we had an error or if the response was a 'Bad Gateway'
   return err || response.statusCode === 502;
 }

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ Request.prototype._tryUntilFail = function () {
     if (response) {
       response.attempts = this.attempts;
     }
-    if (this.retryStrategy(err, response) && this.maxAttempts > 0) {
+    if (this.retryStrategy(err, response, body) && this.maxAttempts > 0) {
       this._timeout = setTimeout(this._tryUntilFail.bind(this), this.retryDelay);
       return;
     }


### PR DESCRIPTION
I've added support for retry strategies that require a test on the response body. This was useful for my project as the server sometimes returned an empty response when it should have returned results.