### PR TITLE
Reject the promise on 4XX and 5XX responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ npm-debug.log
 .env
 coverage
 .vscode
+.idea
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,299 +1,287 @@
-<a name="1.1.0"></a>
-# 1.1.0 (2018-03-01)
-
-* Bump versions as bad package-lock published ([66f0164](https://github.com/hmcts/node-request-retry/commit/66f0164))
-* Reject promises on 4XX and 5XX responses (#1) ([2dca4b3](https://github.com/hmcts/node-request-retry/commit/2dca4b3))
-* Reject promises with request-promise StatusCodeError (#2) ([50fed0f](https://github.com/hmcts/node-request-retry/commit/50fed0f))
-* docs(changelog): updated ([282c849](https://github.com/hmcts/node-request-retry/commit/282c849))
-* docs(changelog): updated ([2cff7a4](https://github.com/hmcts/node-request-retry/commit/2cff7a4))
-* docs(changelog): updated ([54a604a](https://github.com/hmcts/node-request-retry/commit/54a604a))
-
-
-
 <a name="1.13.0"></a>
 # 1.13.0 (2018-01-18)
 
-* fix(logic) ([3c4751e](https://github.com/hmcts/node-request-retry/commit/3c4751e))
-* Release v1.13.0. ([8382911](https://github.com/hmcts/node-request-retry/commit/8382911))
-* style(package) ([f1ecd63](https://github.com/hmcts/node-request-retry/commit/f1ecd63))
-* docs(changelog): updated ([d8c94c3](https://github.com/hmcts/node-request-retry/commit/d8c94c3))
+* fix(logic) ([3c4751e](https://github.com/FGRibreau/node-request-retry/commit/3c4751e))
+* Release v1.13.0. ([8382911](https://github.com/FGRibreau/node-request-retry/commit/8382911))
+* style(package) ([f1ecd63](https://github.com/FGRibreau/node-request-retry/commit/f1ecd63))
+* docs(changelog): updated ([d8c94c3](https://github.com/FGRibreau/node-request-retry/commit/d8c94c3))
 
 
 
 <a name="1.12.3"></a>
 ## 1.12.3 (2018-01-18)
 
-* Added testing for error object attempts reporting ([578870f](https://github.com/hmcts/node-request-retry/commit/578870f))
-* Added the attempts property and assigned it to the error object returned when a network error occurs ([ecd9f5c](https://github.com/hmcts/node-request-retry/commit/ecd9f5c))
-* Adds exponential backoff example to readme. ([184b84f](https://github.com/hmcts/node-request-retry/commit/184b84f))
-* Release v1.12.3. ([57bb3d8](https://github.com/hmcts/node-request-retry/commit/57bb3d8))
-* Typo in Readme for Exponential Backoff Delay. ([b9ef000](https://github.com/hmcts/node-request-retry/commit/b9ef000))
-* Update attempts.test.js ([32a699d](https://github.com/hmcts/node-request-retry/commit/32a699d))
-* Update README.md ([9d1367b](https://github.com/hmcts/node-request-retry/commit/9d1367b))
-* Update README.md ([eed7f88](https://github.com/hmcts/node-request-retry/commit/eed7f88))
-* chore(git): remove package-lock.json from gitignore ([08631fa](https://github.com/hmcts/node-request-retry/commit/08631fa))
-* docs(changelog): updated ([cbe2355](https://github.com/hmcts/node-request-retry/commit/cbe2355))
+* Added testing for error object attempts reporting ([578870f](https://github.com/FGRibreau/node-request-retry/commit/578870f))
+* Added the attempts property and assigned it to the error object returned when a network error occurs ([ecd9f5c](https://github.com/FGRibreau/node-request-retry/commit/ecd9f5c))
+* Adds exponential backoff example to readme. ([184b84f](https://github.com/FGRibreau/node-request-retry/commit/184b84f))
+* Release v1.12.3. ([57bb3d8](https://github.com/FGRibreau/node-request-retry/commit/57bb3d8))
+* Typo in Readme for Exponential Backoff Delay. ([b9ef000](https://github.com/FGRibreau/node-request-retry/commit/b9ef000))
+* Update attempts.test.js ([32a699d](https://github.com/FGRibreau/node-request-retry/commit/32a699d))
+* Update README.md ([9d1367b](https://github.com/FGRibreau/node-request-retry/commit/9d1367b))
+* Update README.md ([eed7f88](https://github.com/FGRibreau/node-request-retry/commit/eed7f88))
+* chore(git): remove package-lock.json from gitignore ([08631fa](https://github.com/FGRibreau/node-request-retry/commit/08631fa))
+* docs(changelog): updated ([cbe2355](https://github.com/FGRibreau/node-request-retry/commit/cbe2355))
 
 
 
 <a name="1.12.2"></a>
 ## 1.12.2 (2017-08-01)
 
-* Added .auth, .jar and .cookie implementations along with corresponding tests ([15afe79](https://github.com/hmcts/node-request-retry/commit/15afe79))
-* formatting updated + version bump ([6ad6f09](https://github.com/hmcts/node-request-retry/commit/6ad6f09))
-* Improve README. ([5052add](https://github.com/hmcts/node-request-retry/commit/5052add))
-* minor fix ([5b3f6d1](https://github.com/hmcts/node-request-retry/commit/5b3f6d1))
-* Release v1.12.1. ([a1d198a](https://github.com/hmcts/node-request-retry/commit/a1d198a))
-* Release v1.12.2. ([eba306c](https://github.com/hmcts/node-request-retry/commit/eba306c))
-* revert ([d6a840f](https://github.com/hmcts/node-request-retry/commit/d6a840f))
-* split various.test.js in auth.test.js and cookie.test.js ([c80272b](https://github.com/hmcts/node-request-retry/commit/c80272b))
-* Update package.json ([9619999](https://github.com/hmcts/node-request-retry/commit/9619999))
-* Update README.md ([9a50640](https://github.com/hmcts/node-request-retry/commit/9a50640))
-* Update README.md ([ada51e3](https://github.com/hmcts/node-request-retry/commit/ada51e3))
-* Update README.md ([984fd17](https://github.com/hmcts/node-request-retry/commit/984fd17))
-* Update README.md ([94b8c01](https://github.com/hmcts/node-request-retry/commit/94b8c01))
-* chore(package): update dependencies ([85c62ac](https://github.com/hmcts/node-request-retry/commit/85c62ac))
-* chore(package): update nyc to version 10.0.0 ([f652825](https://github.com/hmcts/node-request-retry/commit/f652825))
-* chore(package): update nyc to version 9.0.1 ([e376616](https://github.com/hmcts/node-request-retry/commit/e376616))
-* chore(package): update sinon to version 1.17.6 ([2735e7c](https://github.com/hmcts/node-request-retry/commit/2735e7c))
-* docs(changelog): updated ([448b9e1](https://github.com/hmcts/node-request-retry/commit/448b9e1))
+* Added .auth, .jar and .cookie implementations along with corresponding tests ([15afe79](https://github.com/FGRibreau/node-request-retry/commit/15afe79))
+* formatting updated + version bump ([6ad6f09](https://github.com/FGRibreau/node-request-retry/commit/6ad6f09))
+* Improve README. ([5052add](https://github.com/FGRibreau/node-request-retry/commit/5052add))
+* minor fix ([5b3f6d1](https://github.com/FGRibreau/node-request-retry/commit/5b3f6d1))
+* Release v1.12.1. ([a1d198a](https://github.com/FGRibreau/node-request-retry/commit/a1d198a))
+* Release v1.12.2. ([eba306c](https://github.com/FGRibreau/node-request-retry/commit/eba306c))
+* revert ([d6a840f](https://github.com/FGRibreau/node-request-retry/commit/d6a840f))
+* split various.test.js in auth.test.js and cookie.test.js ([c80272b](https://github.com/FGRibreau/node-request-retry/commit/c80272b))
+* Update package.json ([9619999](https://github.com/FGRibreau/node-request-retry/commit/9619999))
+* Update README.md ([9a50640](https://github.com/FGRibreau/node-request-retry/commit/9a50640))
+* Update README.md ([ada51e3](https://github.com/FGRibreau/node-request-retry/commit/ada51e3))
+* Update README.md ([984fd17](https://github.com/FGRibreau/node-request-retry/commit/984fd17))
+* Update README.md ([94b8c01](https://github.com/FGRibreau/node-request-retry/commit/94b8c01))
+* chore(package): update dependencies ([85c62ac](https://github.com/FGRibreau/node-request-retry/commit/85c62ac))
+* chore(package): update nyc to version 10.0.0 ([f652825](https://github.com/FGRibreau/node-request-retry/commit/f652825))
+* chore(package): update nyc to version 9.0.1 ([e376616](https://github.com/FGRibreau/node-request-retry/commit/e376616))
+* chore(package): update sinon to version 1.17.6 ([2735e7c](https://github.com/FGRibreau/node-request-retry/commit/2735e7c))
+* docs(changelog): updated ([448b9e1](https://github.com/FGRibreau/node-request-retry/commit/448b9e1))
 
 
 
 <a name="1.12.0"></a>
 # 1.12.0 (2016-09-07)
 
-* Add delay strategy ([ce99e46](https://github.com/hmcts/node-request-retry/commit/ce99e46))
-* docs(delayStrategy) ([be1fdc3](https://github.com/hmcts/node-request-retry/commit/be1fdc3))
-* Release v1.12.0. ([aef934c](https://github.com/hmcts/node-request-retry/commit/aef934c))
-* Update README.md ([d1fc2ea](https://github.com/hmcts/node-request-retry/commit/d1fc2ea))
-* Update README.md ([fecda40](https://github.com/hmcts/node-request-retry/commit/fecda40))
-* Update README.md ([b7e4133](https://github.com/hmcts/node-request-retry/commit/b7e4133))
-* Update README.md ([5db9276](https://github.com/hmcts/node-request-retry/commit/5db9276))
-* docs(changelog): updated ([757ac28](https://github.com/hmcts/node-request-retry/commit/757ac28))
+* Add delay strategy ([ce99e46](https://github.com/FGRibreau/node-request-retry/commit/ce99e46))
+* docs(delayStrategy) ([be1fdc3](https://github.com/FGRibreau/node-request-retry/commit/be1fdc3))
+* Release v1.12.0. ([aef934c](https://github.com/FGRibreau/node-request-retry/commit/aef934c))
+* Update README.md ([d1fc2ea](https://github.com/FGRibreau/node-request-retry/commit/d1fc2ea))
+* Update README.md ([fecda40](https://github.com/FGRibreau/node-request-retry/commit/fecda40))
+* Update README.md ([b7e4133](https://github.com/FGRibreau/node-request-retry/commit/b7e4133))
+* Update README.md ([5db9276](https://github.com/FGRibreau/node-request-retry/commit/5db9276))
+* docs(changelog): updated ([757ac28](https://github.com/FGRibreau/node-request-retry/commit/757ac28))
 
 
 
 <a name="1.11.0"></a>
 # 1.11.0 (2016-09-03)
 
-* fix(circle) ([e6c2160](https://github.com/hmcts/node-request-retry/commit/e6c2160))
-* fix(deps) ([35921bb](https://github.com/hmcts/node-request-retry/commit/35921bb))
-* Release v1.11.0. ([560e402](https://github.com/hmcts/node-request-retry/commit/560e402))
-* Update README.md ([85b63ad](https://github.com/hmcts/node-request-retry/commit/85b63ad))
-* fix(tests): bring node-request-retry to a 100% code-coverage ([6275780](https://github.com/hmcts/node-request-retry/commit/6275780))
-* feat(api): larger api-surface, just like `request` ([1527f9d](https://github.com/hmcts/node-request-retry/commit/1527f9d))
+* fix(circle) ([e6c2160](https://github.com/FGRibreau/node-request-retry/commit/e6c2160))
+* fix(deps) ([35921bb](https://github.com/FGRibreau/node-request-retry/commit/35921bb))
+* Release v1.11.0. ([560e402](https://github.com/FGRibreau/node-request-retry/commit/560e402))
+* Update README.md ([85b63ad](https://github.com/FGRibreau/node-request-retry/commit/85b63ad))
+* fix(tests): bring node-request-retry to a 100% code-coverage ([6275780](https://github.com/FGRibreau/node-request-retry/commit/6275780))
+* feat(api): larger api-surface, just like `request` ([1527f9d](https://github.com/FGRibreau/node-request-retry/commit/1527f9d))
 
 
 
 <a name="1.10.0"></a>
 # 1.10.0 (2016-08-18)
 
-* Release v1.10.0. ([b1fbef5](https://github.com/hmcts/node-request-retry/commit/b1fbef5))
-* feat(updtr): use updtr ([85bc2c6](https://github.com/hmcts/node-request-retry/commit/85bc2c6))
-* docs(changelog): updated ([4e174ab](https://github.com/hmcts/node-request-retry/commit/4e174ab))
+* Release v1.10.0. ([b1fbef5](https://github.com/FGRibreau/node-request-retry/commit/b1fbef5))
+* feat(updtr): use updtr ([85bc2c6](https://github.com/FGRibreau/node-request-retry/commit/85bc2c6))
+* docs(changelog): updated ([4e174ab](https://github.com/FGRibreau/node-request-retry/commit/4e174ab))
 
 
 
 <a name="1.9.1"></a>
 ## 1.9.1 (2016-07-29)
 
-* fix(changelog) ([9715bd6](https://github.com/hmcts/node-request-retry/commit/9715bd6))
-* fix(readme) ([7e8b8c7](https://github.com/hmcts/node-request-retry/commit/7e8b8c7))
-* Release v1.9.1. ([852e81c](https://github.com/hmcts/node-request-retry/commit/852e81c))
-* Update request to 2.74.0 ([7934049](https://github.com/hmcts/node-request-retry/commit/7934049))
-* docs(changelog): updated ([cc717c7](https://github.com/hmcts/node-request-retry/commit/cc717c7))
+* fix(changelog) ([9715bd6](https://github.com/FGRibreau/node-request-retry/commit/9715bd6))
+* fix(readme) ([7e8b8c7](https://github.com/FGRibreau/node-request-retry/commit/7e8b8c7))
+* Release v1.9.1. ([852e81c](https://github.com/FGRibreau/node-request-retry/commit/852e81c))
+* Update request to 2.74.0 ([7934049](https://github.com/FGRibreau/node-request-retry/commit/7934049))
+* docs(changelog): updated ([cc717c7](https://github.com/FGRibreau/node-request-retry/commit/cc717c7))
 
 
 
 <a name="1.9.0"></a>
 # 1.9.0 (2016-06-22)
 
-* Add support for body-dependent retry strategies ([0f472f9](https://github.com/hmcts/node-request-retry/commit/0f472f9))
-* Amended for body-dependent retry strategies ([db7a4ef](https://github.com/hmcts/node-request-retry/commit/db7a4ef))
-* Release v1.9.0. ([5bdee74](https://github.com/hmcts/node-request-retry/commit/5bdee74))
-* docs(changelog): updated ([ca04ea7](https://github.com/hmcts/node-request-retry/commit/ca04ea7))
+* Add support for body-dependent retry strategies ([0f472f9](https://github.com/FGRibreau/node-request-retry/commit/0f472f9))
+* Amended for body-dependent retry strategies ([db7a4ef](https://github.com/FGRibreau/node-request-retry/commit/db7a4ef))
+* Release v1.9.0. ([5bdee74](https://github.com/FGRibreau/node-request-retry/commit/5bdee74))
+* docs(changelog): updated ([ca04ea7](https://github.com/FGRibreau/node-request-retry/commit/ca04ea7))
 
 
 
 <a name="1.8.0"></a>
 # 1.8.0 (2016-05-11)
 
-* Release v1.8.0. ([6767b49](https://github.com/hmcts/node-request-retry/commit/6767b49))
-* docs(changelog): updated ([97d6429](https://github.com/hmcts/node-request-retry/commit/97d6429))
+* Release v1.8.0. ([6767b49](https://github.com/FGRibreau/node-request-retry/commit/6767b49))
+* docs(changelog): updated ([97d6429](https://github.com/FGRibreau/node-request-retry/commit/97d6429))
 
 
 
 <a name="1.7.1"></a>
 ## 1.7.1 (2016-05-11)
 
-* Add support for .get/.post/... helpers ([0cb9e61](https://github.com/hmcts/node-request-retry/commit/0cb9e61))
-* Release v1.7.1. ([55ab78a](https://github.com/hmcts/node-request-retry/commit/55ab78a))
-* defaults(): use extend for "deep" defaulting ([b514a81](https://github.com/hmcts/node-request-retry/commit/b514a81))
-* docs(changelog): updated ([9e29831](https://github.com/hmcts/node-request-retry/commit/9e29831))
-* fix(changelog): migrated changelog from ruby to js ([777ca04](https://github.com/hmcts/node-request-retry/commit/777ca04))
+* Add support for .get/.post/... helpers ([0cb9e61](https://github.com/FGRibreau/node-request-retry/commit/0cb9e61))
+* Release v1.7.1. ([55ab78a](https://github.com/FGRibreau/node-request-retry/commit/55ab78a))
+* defaults(): use extend for "deep" defaulting ([b514a81](https://github.com/FGRibreau/node-request-retry/commit/b514a81))
+* docs(changelog): updated ([9e29831](https://github.com/FGRibreau/node-request-retry/commit/9e29831))
+* fix(changelog): migrated changelog from ruby to js ([777ca04](https://github.com/FGRibreau/node-request-retry/commit/777ca04))
 
 
 
 <a name="1.7.0"></a>
 # 1.7.0 (2016-05-06)
 
-* docs(changelog) ([f8e793f](https://github.com/hmcts/node-request-retry/commit/f8e793f))
-* docs(readme) ([f76572d](https://github.com/hmcts/node-request-retry/commit/f76572d))
-* docs(README) ([29b98ea](https://github.com/hmcts/node-request-retry/commit/29b98ea))
-* Release v1.7.0. ([762e150](https://github.com/hmcts/node-request-retry/commit/762e150))
-* Support for request default options. Issue #11 ([70b27ec](https://github.com/hmcts/node-request-retry/commit/70b27ec))
-* Update README.md ([0e684c8](https://github.com/hmcts/node-request-retry/commit/0e684c8))
-* Update README.md ([b45d6b7](https://github.com/hmcts/node-request-retry/commit/b45d6b7))
-* Update README.md ([239e75d](https://github.com/hmcts/node-request-retry/commit/239e75d))
+* docs(changelog) ([f8e793f](https://github.com/FGRibreau/node-request-retry/commit/f8e793f))
+* docs(readme) ([f76572d](https://github.com/FGRibreau/node-request-retry/commit/f76572d))
+* docs(README) ([29b98ea](https://github.com/FGRibreau/node-request-retry/commit/29b98ea))
+* Release v1.7.0. ([762e150](https://github.com/FGRibreau/node-request-retry/commit/762e150))
+* Support for request default options. Issue #11 ([70b27ec](https://github.com/FGRibreau/node-request-retry/commit/70b27ec))
+* Update README.md ([0e684c8](https://github.com/FGRibreau/node-request-retry/commit/0e684c8))
+* Update README.md ([b45d6b7](https://github.com/FGRibreau/node-request-retry/commit/b45d6b7))
+* Update README.md ([239e75d](https://github.com/FGRibreau/node-request-retry/commit/239e75d))
 
 
 
 <a name="1.6.0"></a>
 # 1.6.0 (2015-12-25)
 
-* Added bluebird and nock dependencies ([2062358](https://github.com/hmcts/node-request-retry/commit/2062358))
-* Added tests for `promiseFactory` option, using (when.js, Q, kew, RSVP.js) promises libraries ([2cd5c6a](https://github.com/hmcts/node-request-retry/commit/2cd5c6a))
-* docs(changelog) ([55efd7d](https://github.com/hmcts/node-request-retry/commit/55efd7d))
-* docs(readme) ([41e893b](https://github.com/hmcts/node-request-retry/commit/41e893b))
-* docs(readme) ([d291e9b](https://github.com/hmcts/node-request-retry/commit/d291e9b))
-* fix(index) ([51d087c](https://github.com/hmcts/node-request-retry/commit/51d087c))
-* Fixed typo ([f24205d](https://github.com/hmcts/node-request-retry/commit/f24205d))
-* Implemented `promiseFactory` option, to allow usage of different promise libraries ([7a5e11c](https://github.com/hmcts/node-request-retry/commit/7a5e11c))
-* Implemented promises support ([27484f0](https://github.com/hmcts/node-request-retry/commit/27484f0))
-* Implemented tests for promises ([609d820](https://github.com/hmcts/node-request-retry/commit/609d820))
-* Minor example text fix ([2edefc4](https://github.com/hmcts/node-request-retry/commit/2edefc4))
-* Release v1.6.0. ([99118dd](https://github.com/hmcts/node-request-retry/commit/99118dd))
-* Removed test suite exclusive `only` modifier ([71ec0d2](https://github.com/hmcts/node-request-retry/commit/71ec0d2))
-* Updated README for usage with promises ([d66a77a](https://github.com/hmcts/node-request-retry/commit/d66a77a))
-* feat(promise): using when.js by default instead of bluebird ([f9dddf9](https://github.com/hmcts/node-request-retry/commit/f9dddf9))
+* Added bluebird and nock dependencies ([2062358](https://github.com/FGRibreau/node-request-retry/commit/2062358))
+* Added tests for `promiseFactory` option, using (when.js, Q, kew, RSVP.js) promises libraries ([2cd5c6a](https://github.com/FGRibreau/node-request-retry/commit/2cd5c6a))
+* docs(changelog) ([55efd7d](https://github.com/FGRibreau/node-request-retry/commit/55efd7d))
+* docs(readme) ([41e893b](https://github.com/FGRibreau/node-request-retry/commit/41e893b))
+* docs(readme) ([d291e9b](https://github.com/FGRibreau/node-request-retry/commit/d291e9b))
+* fix(index) ([51d087c](https://github.com/FGRibreau/node-request-retry/commit/51d087c))
+* Fixed typo ([f24205d](https://github.com/FGRibreau/node-request-retry/commit/f24205d))
+* Implemented `promiseFactory` option, to allow usage of different promise libraries ([7a5e11c](https://github.com/FGRibreau/node-request-retry/commit/7a5e11c))
+* Implemented promises support ([27484f0](https://github.com/FGRibreau/node-request-retry/commit/27484f0))
+* Implemented tests for promises ([609d820](https://github.com/FGRibreau/node-request-retry/commit/609d820))
+* Minor example text fix ([2edefc4](https://github.com/FGRibreau/node-request-retry/commit/2edefc4))
+* Release v1.6.0. ([99118dd](https://github.com/FGRibreau/node-request-retry/commit/99118dd))
+* Removed test suite exclusive `only` modifier ([71ec0d2](https://github.com/FGRibreau/node-request-retry/commit/71ec0d2))
+* Updated README for usage with promises ([d66a77a](https://github.com/FGRibreau/node-request-retry/commit/d66a77a))
+* feat(promise): using when.js by default instead of bluebird ([f9dddf9](https://github.com/FGRibreau/node-request-retry/commit/f9dddf9))
 
 
 
 <a name="1.5.0"></a>
 # 1.5.0 (2015-09-24)
 
-* Actually add attempts test ([0db5402](https://github.com/hmcts/node-request-retry/commit/0db5402))
-* Add the attempts property for retry attempt info.  Add a test for it.  Also fix maxAttempts being of ([a130355](https://github.com/hmcts/node-request-retry/commit/a130355))
-* feat(changelog) ([bf0ff38](https://github.com/hmcts/node-request-retry/commit/bf0ff38))
-* Release v1.5.0. ([1b7ca7c](https://github.com/hmcts/node-request-retry/commit/1b7ca7c))
-* fix(dot-files): .env to ignored files ([145a33e](https://github.com/hmcts/node-request-retry/commit/145a33e))
+* Actually add attempts test ([0db5402](https://github.com/FGRibreau/node-request-retry/commit/0db5402))
+* Add the attempts property for retry attempt info.  Add a test for it.  Also fix maxAttempts being of ([a130355](https://github.com/FGRibreau/node-request-retry/commit/a130355))
+* feat(changelog) ([bf0ff38](https://github.com/FGRibreau/node-request-retry/commit/bf0ff38))
+* Release v1.5.0. ([1b7ca7c](https://github.com/FGRibreau/node-request-retry/commit/1b7ca7c))
+* fix(dot-files): .env to ignored files ([145a33e](https://github.com/FGRibreau/node-request-retry/commit/145a33e))
 
 
 
 <a name="1.4.1"></a>
 ## 1.4.1 (2015-09-21)
 
-* docs(changelog) ([86ff058](https://github.com/hmcts/node-request-retry/commit/86ff058))
-* Release v1.4.1. ([9f6cadf](https://github.com/hmcts/node-request-retry/commit/9f6cadf))
-* Update dependencies ([5d51d4f](https://github.com/hmcts/node-request-retry/commit/5d51d4f))
-* Update README.md ([2c92e64](https://github.com/hmcts/node-request-retry/commit/2c92e64))
-* Update README.md ([4fc5e92](https://github.com/hmcts/node-request-retry/commit/4fc5e92))
-* fix(package): rolled back version ([5a3628a](https://github.com/hmcts/node-request-retry/commit/5a3628a))
+* docs(changelog) ([86ff058](https://github.com/FGRibreau/node-request-retry/commit/86ff058))
+* Release v1.4.1. ([9f6cadf](https://github.com/FGRibreau/node-request-retry/commit/9f6cadf))
+* Update dependencies ([5d51d4f](https://github.com/FGRibreau/node-request-retry/commit/5d51d4f))
+* Update README.md ([2c92e64](https://github.com/FGRibreau/node-request-retry/commit/2c92e64))
+* Update README.md ([4fc5e92](https://github.com/FGRibreau/node-request-retry/commit/4fc5e92))
+* fix(package): rolled back version ([5a3628a](https://github.com/FGRibreau/node-request-retry/commit/5a3628a))
 
 
 
 <a name="1.4.0"></a>
 # 1.4.0 (2015-07-16)
 
-* add EAI_AGAIN to the list of retriable network errors ([64b96ff](https://github.com/hmcts/node-request-retry/commit/64b96ff))
-* add notes on request module to readme ([e7acf85](https://github.com/hmcts/node-request-retry/commit/e7acf85))
-* Release v1.4.0. ([e890593](https://github.com/hmcts/node-request-retry/commit/e890593))
-* feat(deps): upgrade request to 2.58.x ([e7d34a1](https://github.com/hmcts/node-request-retry/commit/e7d34a1))
+* add EAI_AGAIN to the list of retriable network errors ([64b96ff](https://github.com/FGRibreau/node-request-retry/commit/64b96ff))
+* add notes on request module to readme ([e7acf85](https://github.com/FGRibreau/node-request-retry/commit/e7acf85))
+* Release v1.4.0. ([e890593](https://github.com/FGRibreau/node-request-retry/commit/e890593))
+* feat(deps): upgrade request to 2.58.x ([e7d34a1](https://github.com/FGRibreau/node-request-retry/commit/e7d34a1))
 
 
 
 <a name="1.3.1"></a>
 ## 1.3.1 (2015-05-06)
 
-* Release v1.3.1. ([bef5dba](https://github.com/hmcts/node-request-retry/commit/bef5dba))
-* docs(changelog): add changelog ([5ea057b](https://github.com/hmcts/node-request-retry/commit/5ea057b))
-* feat(check-build): add check-build ([13c4029](https://github.com/hmcts/node-request-retry/commit/13c4029))
+* Release v1.3.1. ([bef5dba](https://github.com/FGRibreau/node-request-retry/commit/bef5dba))
+* docs(changelog): add changelog ([5ea057b](https://github.com/FGRibreau/node-request-retry/commit/5ea057b))
+* feat(check-build): add check-build ([13c4029](https://github.com/FGRibreau/node-request-retry/commit/13c4029))
 
 
 
 <a name="1.3.0"></a>
 # 1.3.0 (2015-05-06)
 
-* Release v1.3.0. ([07ac122](https://github.com/hmcts/node-request-retry/commit/07ac122))
-* update dependencies for latest version ([30da1b0](https://github.com/hmcts/node-request-retry/commit/30da1b0))
+* Release v1.3.0. ([07ac122](https://github.com/FGRibreau/node-request-retry/commit/07ac122))
+* update dependencies for latest version ([30da1b0](https://github.com/FGRibreau/node-request-retry/commit/30da1b0))
 
 
 
 <a name="1.2.2"></a>
 ## 1.2.2 (2015-01-03)
 
-* docs(readme) ([94cc707](https://github.com/hmcts/node-request-retry/commit/94cc707))
-* Release v1.2.2. ([4ee950b](https://github.com/hmcts/node-request-retry/commit/4ee950b))
-* chore(package): update request deps ([ab0c20b](https://github.com/hmcts/node-request-retry/commit/ab0c20b))
+* docs(readme) ([94cc707](https://github.com/FGRibreau/node-request-retry/commit/94cc707))
+* Release v1.2.2. ([4ee950b](https://github.com/FGRibreau/node-request-retry/commit/4ee950b))
+* chore(package): update request deps ([ab0c20b](https://github.com/FGRibreau/node-request-retry/commit/ab0c20b))
 
 
 
 <a name="1.2.1"></a>
 ## 1.2.1 (2014-11-10)
 
-* add tags for versions ([1b9dddc](https://github.com/hmcts/node-request-retry/commit/1b9dddc))
-* add write method ([ecce4c1](https://github.com/hmcts/node-request-retry/commit/ecce4c1))
-* fix changelog ([fb9c2b0](https://github.com/hmcts/node-request-retry/commit/fb9c2b0))
-* readme ([1e5e74a](https://github.com/hmcts/node-request-retry/commit/1e5e74a))
-* Release v1.2.1. ([1a45d51](https://github.com/hmcts/node-request-retry/commit/1a45d51))
-* update readme ([9c72e94](https://github.com/hmcts/node-request-retry/commit/9c72e94))
-* Update README.md ([6db9b37](https://github.com/hmcts/node-request-retry/commit/6db9b37))
+* add tags for versions ([1b9dddc](https://github.com/FGRibreau/node-request-retry/commit/1b9dddc))
+* add write method ([ecce4c1](https://github.com/FGRibreau/node-request-retry/commit/ecce4c1))
+* fix changelog ([fb9c2b0](https://github.com/FGRibreau/node-request-retry/commit/fb9c2b0))
+* readme ([1e5e74a](https://github.com/FGRibreau/node-request-retry/commit/1e5e74a))
+* Release v1.2.1. ([1a45d51](https://github.com/FGRibreau/node-request-retry/commit/1a45d51))
+* update readme ([9c72e94](https://github.com/FGRibreau/node-request-retry/commit/9c72e94))
+* Update README.md ([6db9b37](https://github.com/FGRibreau/node-request-retry/commit/6db9b37))
 
 
 
 <a name="1.2.0"></a>
 # 1.2.0 (2014-11-03)
 
-* add editorconfig & jshintrc ([835d06a](https://github.com/hmcts/node-request-retry/commit/835d06a))
-* add jshintrc ([145e422](https://github.com/hmcts/node-request-retry/commit/145e422))
-* add strategies and support for user-defined `retryStrategy` ([12779c8](https://github.com/hmcts/node-request-retry/commit/12779c8))
-* add tests for strateies ([fa48977](https://github.com/hmcts/node-request-retry/commit/fa48977))
-* Release v1.2.0. ([103ae76](https://github.com/hmcts/node-request-retry/commit/103ae76))
-* update readme ([e077d8e](https://github.com/hmcts/node-request-retry/commit/e077d8e))
-* update readme ([d0b1750](https://github.com/hmcts/node-request-retry/commit/d0b1750))
+* add editorconfig & jshintrc ([835d06a](https://github.com/FGRibreau/node-request-retry/commit/835d06a))
+* add jshintrc ([145e422](https://github.com/FGRibreau/node-request-retry/commit/145e422))
+* add strategies and support for user-defined `retryStrategy` ([12779c8](https://github.com/FGRibreau/node-request-retry/commit/12779c8))
+* add tests for strateies ([fa48977](https://github.com/FGRibreau/node-request-retry/commit/fa48977))
+* Release v1.2.0. ([103ae76](https://github.com/FGRibreau/node-request-retry/commit/103ae76))
+* update readme ([e077d8e](https://github.com/FGRibreau/node-request-retry/commit/e077d8e))
+* update readme ([d0b1750](https://github.com/FGRibreau/node-request-retry/commit/d0b1750))
 
 
 
 <a name="1.1.0"></a>
 # 1.1.0 (2014-10-27)
 
-* add @juliendangers as contributor ([27206d8](https://github.com/hmcts/node-request-retry/commit/27206d8))
-* apply original format ([04fa9c6](https://github.com/hmcts/node-request-retry/commit/04fa9c6))
-* expose methods from internal Request (end, on, emit, once, setMaxListeners, start, removeListener, p ([7d2a0b5](https://github.com/hmcts/node-request-retry/commit/7d2a0b5))
-* jsformat ([581179a](https://github.com/hmcts/node-request-retry/commit/581179a))
-* Release v1.1.0. ([6708bb0](https://github.com/hmcts/node-request-retry/commit/6708bb0))
-* setting the prototype inside the constructor, will do this at each instanciation. We don't need the  ([ea0f474](https://github.com/hmcts/node-request-retry/commit/ea0f474))
-* update deps ([f62935c](https://github.com/hmcts/node-request-retry/commit/f62935c))
-* update readme ([849b78b](https://github.com/hmcts/node-request-retry/commit/849b78b))
+* add @juliendangers as contributor ([27206d8](https://github.com/FGRibreau/node-request-retry/commit/27206d8))
+* apply original format ([04fa9c6](https://github.com/FGRibreau/node-request-retry/commit/04fa9c6))
+* expose methods from internal Request (end, on, emit, once, setMaxListeners, start, removeListener, p ([7d2a0b5](https://github.com/FGRibreau/node-request-retry/commit/7d2a0b5))
+* jsformat ([581179a](https://github.com/FGRibreau/node-request-retry/commit/581179a))
+* Release v1.1.0. ([6708bb0](https://github.com/FGRibreau/node-request-retry/commit/6708bb0))
+* setting the prototype inside the constructor, will do this at each instanciation. We don't need the  ([ea0f474](https://github.com/FGRibreau/node-request-retry/commit/ea0f474))
+* update deps ([f62935c](https://github.com/FGRibreau/node-request-retry/commit/f62935c))
+* update readme ([849b78b](https://github.com/FGRibreau/node-request-retry/commit/849b78b))
 
 
 
 <a name="1.0.4"></a>
 ## 1.0.4 (2014-09-30)
 
-* EPIPE support ([547ac71](https://github.com/hmcts/node-request-retry/commit/547ac71))
-* Release v1.0.4. ([66e39be](https://github.com/hmcts/node-request-retry/commit/66e39be))
+* EPIPE support ([547ac71](https://github.com/FGRibreau/node-request-retry/commit/547ac71))
+* Release v1.0.4. ([66e39be](https://github.com/FGRibreau/node-request-retry/commit/66e39be))
 
 
 
 <a name="1.0.3"></a>
 ## 1.0.3 (2014-09-23)
 
-* . ([370095e](https://github.com/hmcts/node-request-retry/commit/370095e))
-* .gitignore ([f3b0566](https://github.com/hmcts/node-request-retry/commit/f3b0566))
-* [v1.0.0] stable release, support for .abort() ([f235ed9](https://github.com/hmcts/node-request-retry/commit/f235ed9))
-* Add cancelable ([c31eca0](https://github.com/hmcts/node-request-retry/commit/c31eca0))
-* Added EHOSTUNREACH ([d29c41f](https://github.com/hmcts/node-request-retry/commit/d29c41f))
-* First commit ([5f68f8f](https://github.com/hmcts/node-request-retry/commit/5f68f8f))
-* Readme ([b6ac75f](https://github.com/hmcts/node-request-retry/commit/b6ac75f))
-* Readme ([e524ce9](https://github.com/hmcts/node-request-retry/commit/e524ce9))
-* Readme ([240f5c5](https://github.com/hmcts/node-request-retry/commit/240f5c5))
-* Readme ([7e1a5cb](https://github.com/hmcts/node-request-retry/commit/7e1a5cb))
-* Readme ([a8086e9](https://github.com/hmcts/node-request-retry/commit/a8086e9))
-* Release v1.0.3. ([8ed86e6](https://github.com/hmcts/node-request-retry/commit/8ed86e6))
-* Upgraded `request`, callback is now optional ([031a143](https://github.com/hmcts/node-request-retry/commit/031a143))
-* v1.0.2 ([c0f3b97](https://github.com/hmcts/node-request-retry/commit/c0f3b97))
+* . ([370095e](https://github.com/FGRibreau/node-request-retry/commit/370095e))
+* .gitignore ([f3b0566](https://github.com/FGRibreau/node-request-retry/commit/f3b0566))
+* [v1.0.0] stable release, support for .abort() ([f235ed9](https://github.com/FGRibreau/node-request-retry/commit/f235ed9))
+* Add cancelable ([c31eca0](https://github.com/FGRibreau/node-request-retry/commit/c31eca0))
+* Added EHOSTUNREACH ([d29c41f](https://github.com/FGRibreau/node-request-retry/commit/d29c41f))
+* First commit ([5f68f8f](https://github.com/FGRibreau/node-request-retry/commit/5f68f8f))
+* Readme ([b6ac75f](https://github.com/FGRibreau/node-request-retry/commit/b6ac75f))
+* Readme ([e524ce9](https://github.com/FGRibreau/node-request-retry/commit/e524ce9))
+* Readme ([240f5c5](https://github.com/FGRibreau/node-request-retry/commit/240f5c5))
+* Readme ([7e1a5cb](https://github.com/FGRibreau/node-request-retry/commit/7e1a5cb))
+* Readme ([a8086e9](https://github.com/FGRibreau/node-request-retry/commit/a8086e9))
+* Release v1.0.3. ([8ed86e6](https://github.com/FGRibreau/node-request-retry/commit/8ed86e6))
+* Upgraded `request`, callback is now optional ([031a143](https://github.com/FGRibreau/node-request-retry/commit/031a143))
+* v1.0.2 ([c0f3b97](https://github.com/FGRibreau/node-request-retry/commit/c0f3b97))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-<a name="1.0.0"></a>
-# 1.0.0 (2018-03-01)
+<a name="1.0.1"></a>
+## 1.0.1 (2018-03-01)
 
+* Bump versions as bad package-lock published ([66f0164](https://github.com/hmcts/node-request-retry/commit/66f0164))
 * Reject promises on 4XX and 5XX responses (#1) ([2dca4b3](https://github.com/hmcts/node-request-retry/commit/2dca4b3))
+* docs(changelog): updated ([2cff7a4](https://github.com/hmcts/node-request-retry/commit/2cff7a4))
 * docs(changelog): updated ([54a604a](https://github.com/hmcts/node-request-retry/commit/54a604a))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,287 +1,295 @@
+<a name="1.0.0"></a>
+# 1.0.0 (2018-03-01)
+
+* Reject promises on 4XX and 5XX responses (#1) ([2dca4b3](https://github.com/hmcts/node-request-retry/commit/2dca4b3))
+* docs(changelog): updated ([54a604a](https://github.com/hmcts/node-request-retry/commit/54a604a))
+
+
+
 <a name="1.13.0"></a>
 # 1.13.0 (2018-01-18)
 
-* fix(logic) ([3c4751e](https://github.com/FGRibreau/node-request-retry/commit/3c4751e))
-* Release v1.13.0. ([8382911](https://github.com/FGRibreau/node-request-retry/commit/8382911))
-* style(package) ([f1ecd63](https://github.com/FGRibreau/node-request-retry/commit/f1ecd63))
-* docs(changelog): updated ([d8c94c3](https://github.com/FGRibreau/node-request-retry/commit/d8c94c3))
+* fix(logic) ([3c4751e](https://github.com/hmcts/node-request-retry/commit/3c4751e))
+* Release v1.13.0. ([8382911](https://github.com/hmcts/node-request-retry/commit/8382911))
+* style(package) ([f1ecd63](https://github.com/hmcts/node-request-retry/commit/f1ecd63))
+* docs(changelog): updated ([d8c94c3](https://github.com/hmcts/node-request-retry/commit/d8c94c3))
 
 
 
 <a name="1.12.3"></a>
 ## 1.12.3 (2018-01-18)
 
-* Added testing for error object attempts reporting ([578870f](https://github.com/FGRibreau/node-request-retry/commit/578870f))
-* Added the attempts property and assigned it to the error object returned when a network error occurs ([ecd9f5c](https://github.com/FGRibreau/node-request-retry/commit/ecd9f5c))
-* Adds exponential backoff example to readme. ([184b84f](https://github.com/FGRibreau/node-request-retry/commit/184b84f))
-* Release v1.12.3. ([57bb3d8](https://github.com/FGRibreau/node-request-retry/commit/57bb3d8))
-* Typo in Readme for Exponential Backoff Delay. ([b9ef000](https://github.com/FGRibreau/node-request-retry/commit/b9ef000))
-* Update attempts.test.js ([32a699d](https://github.com/FGRibreau/node-request-retry/commit/32a699d))
-* Update README.md ([9d1367b](https://github.com/FGRibreau/node-request-retry/commit/9d1367b))
-* Update README.md ([eed7f88](https://github.com/FGRibreau/node-request-retry/commit/eed7f88))
-* chore(git): remove package-lock.json from gitignore ([08631fa](https://github.com/FGRibreau/node-request-retry/commit/08631fa))
-* docs(changelog): updated ([cbe2355](https://github.com/FGRibreau/node-request-retry/commit/cbe2355))
+* Added testing for error object attempts reporting ([578870f](https://github.com/hmcts/node-request-retry/commit/578870f))
+* Added the attempts property and assigned it to the error object returned when a network error occurs ([ecd9f5c](https://github.com/hmcts/node-request-retry/commit/ecd9f5c))
+* Adds exponential backoff example to readme. ([184b84f](https://github.com/hmcts/node-request-retry/commit/184b84f))
+* Release v1.12.3. ([57bb3d8](https://github.com/hmcts/node-request-retry/commit/57bb3d8))
+* Typo in Readme for Exponential Backoff Delay. ([b9ef000](https://github.com/hmcts/node-request-retry/commit/b9ef000))
+* Update attempts.test.js ([32a699d](https://github.com/hmcts/node-request-retry/commit/32a699d))
+* Update README.md ([9d1367b](https://github.com/hmcts/node-request-retry/commit/9d1367b))
+* Update README.md ([eed7f88](https://github.com/hmcts/node-request-retry/commit/eed7f88))
+* chore(git): remove package-lock.json from gitignore ([08631fa](https://github.com/hmcts/node-request-retry/commit/08631fa))
+* docs(changelog): updated ([cbe2355](https://github.com/hmcts/node-request-retry/commit/cbe2355))
 
 
 
 <a name="1.12.2"></a>
 ## 1.12.2 (2017-08-01)
 
-* Added .auth, .jar and .cookie implementations along with corresponding tests ([15afe79](https://github.com/FGRibreau/node-request-retry/commit/15afe79))
-* formatting updated + version bump ([6ad6f09](https://github.com/FGRibreau/node-request-retry/commit/6ad6f09))
-* Improve README. ([5052add](https://github.com/FGRibreau/node-request-retry/commit/5052add))
-* minor fix ([5b3f6d1](https://github.com/FGRibreau/node-request-retry/commit/5b3f6d1))
-* Release v1.12.1. ([a1d198a](https://github.com/FGRibreau/node-request-retry/commit/a1d198a))
-* Release v1.12.2. ([eba306c](https://github.com/FGRibreau/node-request-retry/commit/eba306c))
-* revert ([d6a840f](https://github.com/FGRibreau/node-request-retry/commit/d6a840f))
-* split various.test.js in auth.test.js and cookie.test.js ([c80272b](https://github.com/FGRibreau/node-request-retry/commit/c80272b))
-* Update package.json ([9619999](https://github.com/FGRibreau/node-request-retry/commit/9619999))
-* Update README.md ([9a50640](https://github.com/FGRibreau/node-request-retry/commit/9a50640))
-* Update README.md ([ada51e3](https://github.com/FGRibreau/node-request-retry/commit/ada51e3))
-* Update README.md ([984fd17](https://github.com/FGRibreau/node-request-retry/commit/984fd17))
-* Update README.md ([94b8c01](https://github.com/FGRibreau/node-request-retry/commit/94b8c01))
-* chore(package): update dependencies ([85c62ac](https://github.com/FGRibreau/node-request-retry/commit/85c62ac))
-* chore(package): update nyc to version 10.0.0 ([f652825](https://github.com/FGRibreau/node-request-retry/commit/f652825))
-* chore(package): update nyc to version 9.0.1 ([e376616](https://github.com/FGRibreau/node-request-retry/commit/e376616))
-* chore(package): update sinon to version 1.17.6 ([2735e7c](https://github.com/FGRibreau/node-request-retry/commit/2735e7c))
-* docs(changelog): updated ([448b9e1](https://github.com/FGRibreau/node-request-retry/commit/448b9e1))
+* Added .auth, .jar and .cookie implementations along with corresponding tests ([15afe79](https://github.com/hmcts/node-request-retry/commit/15afe79))
+* formatting updated + version bump ([6ad6f09](https://github.com/hmcts/node-request-retry/commit/6ad6f09))
+* Improve README. ([5052add](https://github.com/hmcts/node-request-retry/commit/5052add))
+* minor fix ([5b3f6d1](https://github.com/hmcts/node-request-retry/commit/5b3f6d1))
+* Release v1.12.1. ([a1d198a](https://github.com/hmcts/node-request-retry/commit/a1d198a))
+* Release v1.12.2. ([eba306c](https://github.com/hmcts/node-request-retry/commit/eba306c))
+* revert ([d6a840f](https://github.com/hmcts/node-request-retry/commit/d6a840f))
+* split various.test.js in auth.test.js and cookie.test.js ([c80272b](https://github.com/hmcts/node-request-retry/commit/c80272b))
+* Update package.json ([9619999](https://github.com/hmcts/node-request-retry/commit/9619999))
+* Update README.md ([9a50640](https://github.com/hmcts/node-request-retry/commit/9a50640))
+* Update README.md ([ada51e3](https://github.com/hmcts/node-request-retry/commit/ada51e3))
+* Update README.md ([984fd17](https://github.com/hmcts/node-request-retry/commit/984fd17))
+* Update README.md ([94b8c01](https://github.com/hmcts/node-request-retry/commit/94b8c01))
+* chore(package): update dependencies ([85c62ac](https://github.com/hmcts/node-request-retry/commit/85c62ac))
+* chore(package): update nyc to version 10.0.0 ([f652825](https://github.com/hmcts/node-request-retry/commit/f652825))
+* chore(package): update nyc to version 9.0.1 ([e376616](https://github.com/hmcts/node-request-retry/commit/e376616))
+* chore(package): update sinon to version 1.17.6 ([2735e7c](https://github.com/hmcts/node-request-retry/commit/2735e7c))
+* docs(changelog): updated ([448b9e1](https://github.com/hmcts/node-request-retry/commit/448b9e1))
 
 
 
 <a name="1.12.0"></a>
 # 1.12.0 (2016-09-07)
 
-* Add delay strategy ([ce99e46](https://github.com/FGRibreau/node-request-retry/commit/ce99e46))
-* docs(delayStrategy) ([be1fdc3](https://github.com/FGRibreau/node-request-retry/commit/be1fdc3))
-* Release v1.12.0. ([aef934c](https://github.com/FGRibreau/node-request-retry/commit/aef934c))
-* Update README.md ([d1fc2ea](https://github.com/FGRibreau/node-request-retry/commit/d1fc2ea))
-* Update README.md ([fecda40](https://github.com/FGRibreau/node-request-retry/commit/fecda40))
-* Update README.md ([b7e4133](https://github.com/FGRibreau/node-request-retry/commit/b7e4133))
-* Update README.md ([5db9276](https://github.com/FGRibreau/node-request-retry/commit/5db9276))
-* docs(changelog): updated ([757ac28](https://github.com/FGRibreau/node-request-retry/commit/757ac28))
+* Add delay strategy ([ce99e46](https://github.com/hmcts/node-request-retry/commit/ce99e46))
+* docs(delayStrategy) ([be1fdc3](https://github.com/hmcts/node-request-retry/commit/be1fdc3))
+* Release v1.12.0. ([aef934c](https://github.com/hmcts/node-request-retry/commit/aef934c))
+* Update README.md ([d1fc2ea](https://github.com/hmcts/node-request-retry/commit/d1fc2ea))
+* Update README.md ([fecda40](https://github.com/hmcts/node-request-retry/commit/fecda40))
+* Update README.md ([b7e4133](https://github.com/hmcts/node-request-retry/commit/b7e4133))
+* Update README.md ([5db9276](https://github.com/hmcts/node-request-retry/commit/5db9276))
+* docs(changelog): updated ([757ac28](https://github.com/hmcts/node-request-retry/commit/757ac28))
 
 
 
 <a name="1.11.0"></a>
 # 1.11.0 (2016-09-03)
 
-* fix(circle) ([e6c2160](https://github.com/FGRibreau/node-request-retry/commit/e6c2160))
-* fix(deps) ([35921bb](https://github.com/FGRibreau/node-request-retry/commit/35921bb))
-* Release v1.11.0. ([560e402](https://github.com/FGRibreau/node-request-retry/commit/560e402))
-* Update README.md ([85b63ad](https://github.com/FGRibreau/node-request-retry/commit/85b63ad))
-* fix(tests): bring node-request-retry to a 100% code-coverage ([6275780](https://github.com/FGRibreau/node-request-retry/commit/6275780))
-* feat(api): larger api-surface, just like `request` ([1527f9d](https://github.com/FGRibreau/node-request-retry/commit/1527f9d))
+* fix(circle) ([e6c2160](https://github.com/hmcts/node-request-retry/commit/e6c2160))
+* fix(deps) ([35921bb](https://github.com/hmcts/node-request-retry/commit/35921bb))
+* Release v1.11.0. ([560e402](https://github.com/hmcts/node-request-retry/commit/560e402))
+* Update README.md ([85b63ad](https://github.com/hmcts/node-request-retry/commit/85b63ad))
+* fix(tests): bring node-request-retry to a 100% code-coverage ([6275780](https://github.com/hmcts/node-request-retry/commit/6275780))
+* feat(api): larger api-surface, just like `request` ([1527f9d](https://github.com/hmcts/node-request-retry/commit/1527f9d))
 
 
 
 <a name="1.10.0"></a>
 # 1.10.0 (2016-08-18)
 
-* Release v1.10.0. ([b1fbef5](https://github.com/FGRibreau/node-request-retry/commit/b1fbef5))
-* feat(updtr): use updtr ([85bc2c6](https://github.com/FGRibreau/node-request-retry/commit/85bc2c6))
-* docs(changelog): updated ([4e174ab](https://github.com/FGRibreau/node-request-retry/commit/4e174ab))
+* Release v1.10.0. ([b1fbef5](https://github.com/hmcts/node-request-retry/commit/b1fbef5))
+* feat(updtr): use updtr ([85bc2c6](https://github.com/hmcts/node-request-retry/commit/85bc2c6))
+* docs(changelog): updated ([4e174ab](https://github.com/hmcts/node-request-retry/commit/4e174ab))
 
 
 
 <a name="1.9.1"></a>
 ## 1.9.1 (2016-07-29)
 
-* fix(changelog) ([9715bd6](https://github.com/FGRibreau/node-request-retry/commit/9715bd6))
-* fix(readme) ([7e8b8c7](https://github.com/FGRibreau/node-request-retry/commit/7e8b8c7))
-* Release v1.9.1. ([852e81c](https://github.com/FGRibreau/node-request-retry/commit/852e81c))
-* Update request to 2.74.0 ([7934049](https://github.com/FGRibreau/node-request-retry/commit/7934049))
-* docs(changelog): updated ([cc717c7](https://github.com/FGRibreau/node-request-retry/commit/cc717c7))
+* fix(changelog) ([9715bd6](https://github.com/hmcts/node-request-retry/commit/9715bd6))
+* fix(readme) ([7e8b8c7](https://github.com/hmcts/node-request-retry/commit/7e8b8c7))
+* Release v1.9.1. ([852e81c](https://github.com/hmcts/node-request-retry/commit/852e81c))
+* Update request to 2.74.0 ([7934049](https://github.com/hmcts/node-request-retry/commit/7934049))
+* docs(changelog): updated ([cc717c7](https://github.com/hmcts/node-request-retry/commit/cc717c7))
 
 
 
 <a name="1.9.0"></a>
 # 1.9.0 (2016-06-22)
 
-* Add support for body-dependent retry strategies ([0f472f9](https://github.com/FGRibreau/node-request-retry/commit/0f472f9))
-* Amended for body-dependent retry strategies ([db7a4ef](https://github.com/FGRibreau/node-request-retry/commit/db7a4ef))
-* Release v1.9.0. ([5bdee74](https://github.com/FGRibreau/node-request-retry/commit/5bdee74))
-* docs(changelog): updated ([ca04ea7](https://github.com/FGRibreau/node-request-retry/commit/ca04ea7))
+* Add support for body-dependent retry strategies ([0f472f9](https://github.com/hmcts/node-request-retry/commit/0f472f9))
+* Amended for body-dependent retry strategies ([db7a4ef](https://github.com/hmcts/node-request-retry/commit/db7a4ef))
+* Release v1.9.0. ([5bdee74](https://github.com/hmcts/node-request-retry/commit/5bdee74))
+* docs(changelog): updated ([ca04ea7](https://github.com/hmcts/node-request-retry/commit/ca04ea7))
 
 
 
 <a name="1.8.0"></a>
 # 1.8.0 (2016-05-11)
 
-* Release v1.8.0. ([6767b49](https://github.com/FGRibreau/node-request-retry/commit/6767b49))
-* docs(changelog): updated ([97d6429](https://github.com/FGRibreau/node-request-retry/commit/97d6429))
+* Release v1.8.0. ([6767b49](https://github.com/hmcts/node-request-retry/commit/6767b49))
+* docs(changelog): updated ([97d6429](https://github.com/hmcts/node-request-retry/commit/97d6429))
 
 
 
 <a name="1.7.1"></a>
 ## 1.7.1 (2016-05-11)
 
-* Add support for .get/.post/... helpers ([0cb9e61](https://github.com/FGRibreau/node-request-retry/commit/0cb9e61))
-* Release v1.7.1. ([55ab78a](https://github.com/FGRibreau/node-request-retry/commit/55ab78a))
-* defaults(): use extend for "deep" defaulting ([b514a81](https://github.com/FGRibreau/node-request-retry/commit/b514a81))
-* docs(changelog): updated ([9e29831](https://github.com/FGRibreau/node-request-retry/commit/9e29831))
-* fix(changelog): migrated changelog from ruby to js ([777ca04](https://github.com/FGRibreau/node-request-retry/commit/777ca04))
+* Add support for .get/.post/... helpers ([0cb9e61](https://github.com/hmcts/node-request-retry/commit/0cb9e61))
+* Release v1.7.1. ([55ab78a](https://github.com/hmcts/node-request-retry/commit/55ab78a))
+* defaults(): use extend for "deep" defaulting ([b514a81](https://github.com/hmcts/node-request-retry/commit/b514a81))
+* docs(changelog): updated ([9e29831](https://github.com/hmcts/node-request-retry/commit/9e29831))
+* fix(changelog): migrated changelog from ruby to js ([777ca04](https://github.com/hmcts/node-request-retry/commit/777ca04))
 
 
 
 <a name="1.7.0"></a>
 # 1.7.0 (2016-05-06)
 
-* docs(changelog) ([f8e793f](https://github.com/FGRibreau/node-request-retry/commit/f8e793f))
-* docs(readme) ([f76572d](https://github.com/FGRibreau/node-request-retry/commit/f76572d))
-* docs(README) ([29b98ea](https://github.com/FGRibreau/node-request-retry/commit/29b98ea))
-* Release v1.7.0. ([762e150](https://github.com/FGRibreau/node-request-retry/commit/762e150))
-* Support for request default options. Issue #11 ([70b27ec](https://github.com/FGRibreau/node-request-retry/commit/70b27ec))
-* Update README.md ([0e684c8](https://github.com/FGRibreau/node-request-retry/commit/0e684c8))
-* Update README.md ([b45d6b7](https://github.com/FGRibreau/node-request-retry/commit/b45d6b7))
-* Update README.md ([239e75d](https://github.com/FGRibreau/node-request-retry/commit/239e75d))
+* docs(changelog) ([f8e793f](https://github.com/hmcts/node-request-retry/commit/f8e793f))
+* docs(readme) ([f76572d](https://github.com/hmcts/node-request-retry/commit/f76572d))
+* docs(README) ([29b98ea](https://github.com/hmcts/node-request-retry/commit/29b98ea))
+* Release v1.7.0. ([762e150](https://github.com/hmcts/node-request-retry/commit/762e150))
+* Support for request default options. Issue #11 ([70b27ec](https://github.com/hmcts/node-request-retry/commit/70b27ec))
+* Update README.md ([0e684c8](https://github.com/hmcts/node-request-retry/commit/0e684c8))
+* Update README.md ([b45d6b7](https://github.com/hmcts/node-request-retry/commit/b45d6b7))
+* Update README.md ([239e75d](https://github.com/hmcts/node-request-retry/commit/239e75d))
 
 
 
 <a name="1.6.0"></a>
 # 1.6.0 (2015-12-25)
 
-* Added bluebird and nock dependencies ([2062358](https://github.com/FGRibreau/node-request-retry/commit/2062358))
-* Added tests for `promiseFactory` option, using (when.js, Q, kew, RSVP.js) promises libraries ([2cd5c6a](https://github.com/FGRibreau/node-request-retry/commit/2cd5c6a))
-* docs(changelog) ([55efd7d](https://github.com/FGRibreau/node-request-retry/commit/55efd7d))
-* docs(readme) ([41e893b](https://github.com/FGRibreau/node-request-retry/commit/41e893b))
-* docs(readme) ([d291e9b](https://github.com/FGRibreau/node-request-retry/commit/d291e9b))
-* fix(index) ([51d087c](https://github.com/FGRibreau/node-request-retry/commit/51d087c))
-* Fixed typo ([f24205d](https://github.com/FGRibreau/node-request-retry/commit/f24205d))
-* Implemented `promiseFactory` option, to allow usage of different promise libraries ([7a5e11c](https://github.com/FGRibreau/node-request-retry/commit/7a5e11c))
-* Implemented promises support ([27484f0](https://github.com/FGRibreau/node-request-retry/commit/27484f0))
-* Implemented tests for promises ([609d820](https://github.com/FGRibreau/node-request-retry/commit/609d820))
-* Minor example text fix ([2edefc4](https://github.com/FGRibreau/node-request-retry/commit/2edefc4))
-* Release v1.6.0. ([99118dd](https://github.com/FGRibreau/node-request-retry/commit/99118dd))
-* Removed test suite exclusive `only` modifier ([71ec0d2](https://github.com/FGRibreau/node-request-retry/commit/71ec0d2))
-* Updated README for usage with promises ([d66a77a](https://github.com/FGRibreau/node-request-retry/commit/d66a77a))
-* feat(promise): using when.js by default instead of bluebird ([f9dddf9](https://github.com/FGRibreau/node-request-retry/commit/f9dddf9))
+* Added bluebird and nock dependencies ([2062358](https://github.com/hmcts/node-request-retry/commit/2062358))
+* Added tests for `promiseFactory` option, using (when.js, Q, kew, RSVP.js) promises libraries ([2cd5c6a](https://github.com/hmcts/node-request-retry/commit/2cd5c6a))
+* docs(changelog) ([55efd7d](https://github.com/hmcts/node-request-retry/commit/55efd7d))
+* docs(readme) ([41e893b](https://github.com/hmcts/node-request-retry/commit/41e893b))
+* docs(readme) ([d291e9b](https://github.com/hmcts/node-request-retry/commit/d291e9b))
+* fix(index) ([51d087c](https://github.com/hmcts/node-request-retry/commit/51d087c))
+* Fixed typo ([f24205d](https://github.com/hmcts/node-request-retry/commit/f24205d))
+* Implemented `promiseFactory` option, to allow usage of different promise libraries ([7a5e11c](https://github.com/hmcts/node-request-retry/commit/7a5e11c))
+* Implemented promises support ([27484f0](https://github.com/hmcts/node-request-retry/commit/27484f0))
+* Implemented tests for promises ([609d820](https://github.com/hmcts/node-request-retry/commit/609d820))
+* Minor example text fix ([2edefc4](https://github.com/hmcts/node-request-retry/commit/2edefc4))
+* Release v1.6.0. ([99118dd](https://github.com/hmcts/node-request-retry/commit/99118dd))
+* Removed test suite exclusive `only` modifier ([71ec0d2](https://github.com/hmcts/node-request-retry/commit/71ec0d2))
+* Updated README for usage with promises ([d66a77a](https://github.com/hmcts/node-request-retry/commit/d66a77a))
+* feat(promise): using when.js by default instead of bluebird ([f9dddf9](https://github.com/hmcts/node-request-retry/commit/f9dddf9))
 
 
 
 <a name="1.5.0"></a>
 # 1.5.0 (2015-09-24)
 
-* Actually add attempts test ([0db5402](https://github.com/FGRibreau/node-request-retry/commit/0db5402))
-* Add the attempts property for retry attempt info.  Add a test for it.  Also fix maxAttempts being of ([a130355](https://github.com/FGRibreau/node-request-retry/commit/a130355))
-* feat(changelog) ([bf0ff38](https://github.com/FGRibreau/node-request-retry/commit/bf0ff38))
-* Release v1.5.0. ([1b7ca7c](https://github.com/FGRibreau/node-request-retry/commit/1b7ca7c))
-* fix(dot-files): .env to ignored files ([145a33e](https://github.com/FGRibreau/node-request-retry/commit/145a33e))
+* Actually add attempts test ([0db5402](https://github.com/hmcts/node-request-retry/commit/0db5402))
+* Add the attempts property for retry attempt info.  Add a test for it.  Also fix maxAttempts being of ([a130355](https://github.com/hmcts/node-request-retry/commit/a130355))
+* feat(changelog) ([bf0ff38](https://github.com/hmcts/node-request-retry/commit/bf0ff38))
+* Release v1.5.0. ([1b7ca7c](https://github.com/hmcts/node-request-retry/commit/1b7ca7c))
+* fix(dot-files): .env to ignored files ([145a33e](https://github.com/hmcts/node-request-retry/commit/145a33e))
 
 
 
 <a name="1.4.1"></a>
 ## 1.4.1 (2015-09-21)
 
-* docs(changelog) ([86ff058](https://github.com/FGRibreau/node-request-retry/commit/86ff058))
-* Release v1.4.1. ([9f6cadf](https://github.com/FGRibreau/node-request-retry/commit/9f6cadf))
-* Update dependencies ([5d51d4f](https://github.com/FGRibreau/node-request-retry/commit/5d51d4f))
-* Update README.md ([2c92e64](https://github.com/FGRibreau/node-request-retry/commit/2c92e64))
-* Update README.md ([4fc5e92](https://github.com/FGRibreau/node-request-retry/commit/4fc5e92))
-* fix(package): rolled back version ([5a3628a](https://github.com/FGRibreau/node-request-retry/commit/5a3628a))
+* docs(changelog) ([86ff058](https://github.com/hmcts/node-request-retry/commit/86ff058))
+* Release v1.4.1. ([9f6cadf](https://github.com/hmcts/node-request-retry/commit/9f6cadf))
+* Update dependencies ([5d51d4f](https://github.com/hmcts/node-request-retry/commit/5d51d4f))
+* Update README.md ([2c92e64](https://github.com/hmcts/node-request-retry/commit/2c92e64))
+* Update README.md ([4fc5e92](https://github.com/hmcts/node-request-retry/commit/4fc5e92))
+* fix(package): rolled back version ([5a3628a](https://github.com/hmcts/node-request-retry/commit/5a3628a))
 
 
 
 <a name="1.4.0"></a>
 # 1.4.0 (2015-07-16)
 
-* add EAI_AGAIN to the list of retriable network errors ([64b96ff](https://github.com/FGRibreau/node-request-retry/commit/64b96ff))
-* add notes on request module to readme ([e7acf85](https://github.com/FGRibreau/node-request-retry/commit/e7acf85))
-* Release v1.4.0. ([e890593](https://github.com/FGRibreau/node-request-retry/commit/e890593))
-* feat(deps): upgrade request to 2.58.x ([e7d34a1](https://github.com/FGRibreau/node-request-retry/commit/e7d34a1))
+* add EAI_AGAIN to the list of retriable network errors ([64b96ff](https://github.com/hmcts/node-request-retry/commit/64b96ff))
+* add notes on request module to readme ([e7acf85](https://github.com/hmcts/node-request-retry/commit/e7acf85))
+* Release v1.4.0. ([e890593](https://github.com/hmcts/node-request-retry/commit/e890593))
+* feat(deps): upgrade request to 2.58.x ([e7d34a1](https://github.com/hmcts/node-request-retry/commit/e7d34a1))
 
 
 
 <a name="1.3.1"></a>
 ## 1.3.1 (2015-05-06)
 
-* Release v1.3.1. ([bef5dba](https://github.com/FGRibreau/node-request-retry/commit/bef5dba))
-* docs(changelog): add changelog ([5ea057b](https://github.com/FGRibreau/node-request-retry/commit/5ea057b))
-* feat(check-build): add check-build ([13c4029](https://github.com/FGRibreau/node-request-retry/commit/13c4029))
+* Release v1.3.1. ([bef5dba](https://github.com/hmcts/node-request-retry/commit/bef5dba))
+* docs(changelog): add changelog ([5ea057b](https://github.com/hmcts/node-request-retry/commit/5ea057b))
+* feat(check-build): add check-build ([13c4029](https://github.com/hmcts/node-request-retry/commit/13c4029))
 
 
 
 <a name="1.3.0"></a>
 # 1.3.0 (2015-05-06)
 
-* Release v1.3.0. ([07ac122](https://github.com/FGRibreau/node-request-retry/commit/07ac122))
-* update dependencies for latest version ([30da1b0](https://github.com/FGRibreau/node-request-retry/commit/30da1b0))
+* Release v1.3.0. ([07ac122](https://github.com/hmcts/node-request-retry/commit/07ac122))
+* update dependencies for latest version ([30da1b0](https://github.com/hmcts/node-request-retry/commit/30da1b0))
 
 
 
 <a name="1.2.2"></a>
 ## 1.2.2 (2015-01-03)
 
-* docs(readme) ([94cc707](https://github.com/FGRibreau/node-request-retry/commit/94cc707))
-* Release v1.2.2. ([4ee950b](https://github.com/FGRibreau/node-request-retry/commit/4ee950b))
-* chore(package): update request deps ([ab0c20b](https://github.com/FGRibreau/node-request-retry/commit/ab0c20b))
+* docs(readme) ([94cc707](https://github.com/hmcts/node-request-retry/commit/94cc707))
+* Release v1.2.2. ([4ee950b](https://github.com/hmcts/node-request-retry/commit/4ee950b))
+* chore(package): update request deps ([ab0c20b](https://github.com/hmcts/node-request-retry/commit/ab0c20b))
 
 
 
 <a name="1.2.1"></a>
 ## 1.2.1 (2014-11-10)
 
-* add tags for versions ([1b9dddc](https://github.com/FGRibreau/node-request-retry/commit/1b9dddc))
-* add write method ([ecce4c1](https://github.com/FGRibreau/node-request-retry/commit/ecce4c1))
-* fix changelog ([fb9c2b0](https://github.com/FGRibreau/node-request-retry/commit/fb9c2b0))
-* readme ([1e5e74a](https://github.com/FGRibreau/node-request-retry/commit/1e5e74a))
-* Release v1.2.1. ([1a45d51](https://github.com/FGRibreau/node-request-retry/commit/1a45d51))
-* update readme ([9c72e94](https://github.com/FGRibreau/node-request-retry/commit/9c72e94))
-* Update README.md ([6db9b37](https://github.com/FGRibreau/node-request-retry/commit/6db9b37))
+* add tags for versions ([1b9dddc](https://github.com/hmcts/node-request-retry/commit/1b9dddc))
+* add write method ([ecce4c1](https://github.com/hmcts/node-request-retry/commit/ecce4c1))
+* fix changelog ([fb9c2b0](https://github.com/hmcts/node-request-retry/commit/fb9c2b0))
+* readme ([1e5e74a](https://github.com/hmcts/node-request-retry/commit/1e5e74a))
+* Release v1.2.1. ([1a45d51](https://github.com/hmcts/node-request-retry/commit/1a45d51))
+* update readme ([9c72e94](https://github.com/hmcts/node-request-retry/commit/9c72e94))
+* Update README.md ([6db9b37](https://github.com/hmcts/node-request-retry/commit/6db9b37))
 
 
 
 <a name="1.2.0"></a>
 # 1.2.0 (2014-11-03)
 
-* add editorconfig & jshintrc ([835d06a](https://github.com/FGRibreau/node-request-retry/commit/835d06a))
-* add jshintrc ([145e422](https://github.com/FGRibreau/node-request-retry/commit/145e422))
-* add strategies and support for user-defined `retryStrategy` ([12779c8](https://github.com/FGRibreau/node-request-retry/commit/12779c8))
-* add tests for strateies ([fa48977](https://github.com/FGRibreau/node-request-retry/commit/fa48977))
-* Release v1.2.0. ([103ae76](https://github.com/FGRibreau/node-request-retry/commit/103ae76))
-* update readme ([e077d8e](https://github.com/FGRibreau/node-request-retry/commit/e077d8e))
-* update readme ([d0b1750](https://github.com/FGRibreau/node-request-retry/commit/d0b1750))
+* add editorconfig & jshintrc ([835d06a](https://github.com/hmcts/node-request-retry/commit/835d06a))
+* add jshintrc ([145e422](https://github.com/hmcts/node-request-retry/commit/145e422))
+* add strategies and support for user-defined `retryStrategy` ([12779c8](https://github.com/hmcts/node-request-retry/commit/12779c8))
+* add tests for strateies ([fa48977](https://github.com/hmcts/node-request-retry/commit/fa48977))
+* Release v1.2.0. ([103ae76](https://github.com/hmcts/node-request-retry/commit/103ae76))
+* update readme ([e077d8e](https://github.com/hmcts/node-request-retry/commit/e077d8e))
+* update readme ([d0b1750](https://github.com/hmcts/node-request-retry/commit/d0b1750))
 
 
 
 <a name="1.1.0"></a>
 # 1.1.0 (2014-10-27)
 
-* add @juliendangers as contributor ([27206d8](https://github.com/FGRibreau/node-request-retry/commit/27206d8))
-* apply original format ([04fa9c6](https://github.com/FGRibreau/node-request-retry/commit/04fa9c6))
-* expose methods from internal Request (end, on, emit, once, setMaxListeners, start, removeListener, p ([7d2a0b5](https://github.com/FGRibreau/node-request-retry/commit/7d2a0b5))
-* jsformat ([581179a](https://github.com/FGRibreau/node-request-retry/commit/581179a))
-* Release v1.1.0. ([6708bb0](https://github.com/FGRibreau/node-request-retry/commit/6708bb0))
-* setting the prototype inside the constructor, will do this at each instanciation. We don't need the  ([ea0f474](https://github.com/FGRibreau/node-request-retry/commit/ea0f474))
-* update deps ([f62935c](https://github.com/FGRibreau/node-request-retry/commit/f62935c))
-* update readme ([849b78b](https://github.com/FGRibreau/node-request-retry/commit/849b78b))
+* add @juliendangers as contributor ([27206d8](https://github.com/hmcts/node-request-retry/commit/27206d8))
+* apply original format ([04fa9c6](https://github.com/hmcts/node-request-retry/commit/04fa9c6))
+* expose methods from internal Request (end, on, emit, once, setMaxListeners, start, removeListener, p ([7d2a0b5](https://github.com/hmcts/node-request-retry/commit/7d2a0b5))
+* jsformat ([581179a](https://github.com/hmcts/node-request-retry/commit/581179a))
+* Release v1.1.0. ([6708bb0](https://github.com/hmcts/node-request-retry/commit/6708bb0))
+* setting the prototype inside the constructor, will do this at each instanciation. We don't need the  ([ea0f474](https://github.com/hmcts/node-request-retry/commit/ea0f474))
+* update deps ([f62935c](https://github.com/hmcts/node-request-retry/commit/f62935c))
+* update readme ([849b78b](https://github.com/hmcts/node-request-retry/commit/849b78b))
 
 
 
 <a name="1.0.4"></a>
 ## 1.0.4 (2014-09-30)
 
-* EPIPE support ([547ac71](https://github.com/FGRibreau/node-request-retry/commit/547ac71))
-* Release v1.0.4. ([66e39be](https://github.com/FGRibreau/node-request-retry/commit/66e39be))
+* EPIPE support ([547ac71](https://github.com/hmcts/node-request-retry/commit/547ac71))
+* Release v1.0.4. ([66e39be](https://github.com/hmcts/node-request-retry/commit/66e39be))
 
 
 
 <a name="1.0.3"></a>
 ## 1.0.3 (2014-09-23)
 
-* . ([370095e](https://github.com/FGRibreau/node-request-retry/commit/370095e))
-* .gitignore ([f3b0566](https://github.com/FGRibreau/node-request-retry/commit/f3b0566))
-* [v1.0.0] stable release, support for .abort() ([f235ed9](https://github.com/FGRibreau/node-request-retry/commit/f235ed9))
-* Add cancelable ([c31eca0](https://github.com/FGRibreau/node-request-retry/commit/c31eca0))
-* Added EHOSTUNREACH ([d29c41f](https://github.com/FGRibreau/node-request-retry/commit/d29c41f))
-* First commit ([5f68f8f](https://github.com/FGRibreau/node-request-retry/commit/5f68f8f))
-* Readme ([b6ac75f](https://github.com/FGRibreau/node-request-retry/commit/b6ac75f))
-* Readme ([e524ce9](https://github.com/FGRibreau/node-request-retry/commit/e524ce9))
-* Readme ([240f5c5](https://github.com/FGRibreau/node-request-retry/commit/240f5c5))
-* Readme ([7e1a5cb](https://github.com/FGRibreau/node-request-retry/commit/7e1a5cb))
-* Readme ([a8086e9](https://github.com/FGRibreau/node-request-retry/commit/a8086e9))
-* Release v1.0.3. ([8ed86e6](https://github.com/FGRibreau/node-request-retry/commit/8ed86e6))
-* Upgraded `request`, callback is now optional ([031a143](https://github.com/FGRibreau/node-request-retry/commit/031a143))
-* v1.0.2 ([c0f3b97](https://github.com/FGRibreau/node-request-retry/commit/c0f3b97))
+* . ([370095e](https://github.com/hmcts/node-request-retry/commit/370095e))
+* .gitignore ([f3b0566](https://github.com/hmcts/node-request-retry/commit/f3b0566))
+* [v1.0.0] stable release, support for .abort() ([f235ed9](https://github.com/hmcts/node-request-retry/commit/f235ed9))
+* Add cancelable ([c31eca0](https://github.com/hmcts/node-request-retry/commit/c31eca0))
+* Added EHOSTUNREACH ([d29c41f](https://github.com/hmcts/node-request-retry/commit/d29c41f))
+* First commit ([5f68f8f](https://github.com/hmcts/node-request-retry/commit/5f68f8f))
+* Readme ([b6ac75f](https://github.com/hmcts/node-request-retry/commit/b6ac75f))
+* Readme ([e524ce9](https://github.com/hmcts/node-request-retry/commit/e524ce9))
+* Readme ([240f5c5](https://github.com/hmcts/node-request-retry/commit/240f5c5))
+* Readme ([7e1a5cb](https://github.com/hmcts/node-request-retry/commit/7e1a5cb))
+* Readme ([a8086e9](https://github.com/hmcts/node-request-retry/commit/a8086e9))
+* Release v1.0.3. ([8ed86e6](https://github.com/hmcts/node-request-retry/commit/8ed86e6))
+* Upgraded `request`, callback is now optional ([031a143](https://github.com/hmcts/node-request-retry/commit/031a143))
+* v1.0.2 ([c0f3b97](https://github.com/hmcts/node-request-retry/commit/c0f3b97))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-<a name="1.0.1"></a>
-## 1.0.1 (2018-03-01)
+<a name="1.1.0"></a>
+# 1.1.0 (2018-03-01)
 
 * Bump versions as bad package-lock published ([66f0164](https://github.com/hmcts/node-request-retry/commit/66f0164))
 * Reject promises on 4XX and 5XX responses (#1) ([2dca4b3](https://github.com/hmcts/node-request-retry/commit/2dca4b3))
+* Reject promises with request-promise StatusCodeError (#2) ([50fed0f](https://github.com/hmcts/node-request-retry/commit/50fed0f))
+* docs(changelog): updated ([282c849](https://github.com/hmcts/node-request-retry/commit/282c849))
 * docs(changelog): updated ([2cff7a4](https://github.com/hmcts/node-request-retry/commit/2cff7a4))
 * docs(changelog): updated ([54a604a](https://github.com/hmcts/node-request-retry/commit/54a604a))
 

--- a/helpers/isErrorResponse.js
+++ b/helpers/isErrorResponse.js
@@ -1,0 +1,11 @@
+/**
+ * Checks if the returned response is an error response.
+ *
+ * @param response a Node's http.IncomingMessage object
+ * @return boolean true if the response status is 4XX or 5XX
+ */
+function isErrorResponse(response) {
+  return response.statusCode >= 400;
+}
+
+module.exports = isErrorResponse;

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var request = require('request');
 var RetryStrategies = require('./strategies');
 var isErrorResponse = require('./helpers/isErrorResponse')
 var _ = require('lodash');
+var { StatusCodeError } = require('request-promise-core/errors');
 
 var DEFAULTS = {
   maxAttempts: 5, // try 5 times
@@ -111,7 +112,7 @@ function Request(url, options, f, retryConfig) {
     }
 
     if (isErrorResponse(response)) {
-      return this._reject(this.fullResponse ? response : body);
+      return this._reject(new StatusCodeError(response.statusCode, body, this.options, response));
     }
 
     // resolve with the full response or just the body

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var extend = require('extend');
 var when = require('when');
 var request = require('request');
 var RetryStrategies = require('./strategies');
+var isErrorResponse = require('./helpers/isErrorResponse')
 var _ = require('lodash');
 
 var DEFAULTS = {
@@ -107,6 +108,10 @@ function Request(url, options, f, retryConfig) {
 
     if (err) {
       return this._reject(err);
+    }
+
+    if (isErrorResponse(response)) {
+      return this._reject(this.fullResponse ? response : body);
     }
 
     // resolve with the full response or just the body

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,9 @@
 {
   "name": "@hmcts/requestretry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -543,8 +533,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -1205,6 +1195,16 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -3321,6 +3321,14 @@
         "tough-cookie": "2.3.2",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.4"
       }
     },
     "right-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,6 +213,12 @@
         "supports-color": "2.0.0"
       }
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "cli-spinner": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz",
@@ -698,6 +704,12 @@
         }
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -811,6 +823,12 @@
       "requires": {
         "is-property": "1.0.2"
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-pkg-repo": {
       "version": "1.4.0",
@@ -1576,6 +1594,81 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nock": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.2.3.tgz",
+      "integrity": "sha512-4XYNSJDJ/PvNoH+cCRWcGOOFsq3jtZdNTRIlPIBA7CopGWJO56m5OaPEjjJ3WddxNYfe5HL9sQQAtMt8oyR9AA==",
+      "dev": true,
+      "requires": {
+        "chai": "4.1.2",
+        "debug": "3.1.0",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "propagate": "1.0.0",
+        "qs": "6.5.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "chai": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+          "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "1.0.2",
+            "check-error": "1.0.2",
+            "deep-eql": "3.0.1",
+            "get-func-name": "2.0.0",
+            "pathval": "1.1.0",
+            "type-detect": "4.0.8"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-eql": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -3080,6 +3173,12 @@
         "pify": "2.3.0"
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
@@ -3110,6 +3209,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
     },
     "punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,19 @@
 {
-  "name": "requestretry",
-  "version": "1.13.0",
+  "name": "@hmcts/requestretry",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -533,8 +543,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -1195,16 +1205,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/hmcts/node-request-retry"
+    "url": "https://github.com/FGRibreau/node-request-retry"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/requestretry",
   "description": "request-retry wrap nodejs request to retry http(s) requests in case of error",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Francois-Guillaume Ribreau",
     "email": "npm@fgribreau.com",
@@ -62,5 +62,8 @@
     "rsvp": "^3.2.1",
     "sinon": "1.17.6",
     "updtr": "^0.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "requestretry",
+  "name": "@hmcts/requestretry",
   "description": "request-retry wrap nodejs request to retry http(s) requests in case of error",
-  "version": "1.13.0",
+  "version": "1.0.0",
   "author": {
     "name": "Francois-Guillaume Ribreau",
     "email": "npm@fgribreau.com",
@@ -18,7 +18,8 @@
     }
   ],
   "repository": {
-    "url": "https://github.com/FGRibreau/node-request-retry"
+    "type": "git",
+    "url": "https://github.com/hmcts/node-request-retry"
   },
   "main": "index.js",
   "scripts": {
@@ -55,6 +56,7 @@
     "coveralls": "^2.11.12",
     "kew": "~0.7.0",
     "mocha": "^3.0.2",
+    "nock": "^9.2.3",
     "nyc": "^10.0.0",
     "q": "~1.4.1",
     "rsvp": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hmcts/requestretry",
   "description": "request-retry wrap nodejs request to retry http(s) requests in case of error",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Francois-Guillaume Ribreau",
     "email": "npm@fgribreau.com",
@@ -46,6 +46,7 @@
     "extend": "^3.0.0",
     "lodash": "^4.15.0",
     "request": "^2.74.0",
+    "request-promise-core": "^1.1.1",
     "when": "^3.7.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,6 @@
     "rsvp": "^3.2.1",
     "sinon": "1.17.6",
     "updtr": "^0.2.1"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@hmcts/requestretry",
+  "name": "requestretry",
   "description": "request-retry wrap nodejs request to retry http(s) requests in case of error",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": {
     "name": "Francois-Guillaume Ribreau",
     "email": "npm@fgribreau.com",

--- a/test/helpers/isErrorResponse.test.js
+++ b/test/helpers/isErrorResponse.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const isErrorResponse = require('../../helpers/isErrorResponse');
+const expect = require('chai').expect;
+
+describe('isErrorResponse', function () {
+  [200, 201, 302].forEach(statusCode => {
+    it(`should return false for ${statusCode} statusCode`, function () {
+      expect(isErrorResponse({ statusCode: statusCode })).to.equal(false);
+    });
+  });
+
+  [400, 401, 403, 422, 500, 502].forEach(statusCode => {
+    it(`should return true for ${statusCode} statusCode`, function () {
+      expect(isErrorResponse({ statusCode: statusCode })).to.equal(true);
+    });
+  });
+});

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -96,7 +96,8 @@ describe('Promises support', function () {
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError
     })
       .catch(function (err) {
-        t.strictEqual(err.body, 'Client Error');
+        t.strictEqual(err.statusCode, 400);
+        t.strictEqual(err.error, 'Client Error');
         done();
       });
   });
@@ -112,7 +113,8 @@ describe('Promises support', function () {
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError
     })
       .catch(function (err) {
-        t.strictEqual(err.body, 'Server Error');
+        t.strictEqual(err.statusCode, 500);
+        t.strictEqual(err.error, 'Server Error');
         done();
       });
   });
@@ -162,7 +164,8 @@ describe('Promises support', function () {
       it('should work on request fail', function (done) {
         makeRequest(customPromiseFactory, done, true)
           .catch(function (err) {
-            t.strictEqual(err, 'Internal Server Error');
+            t.strictEqual(err.statusCode, 500);
+            t.strictEqual(err.error, 'Internal Server Error');
             done();
           });
       });
@@ -180,7 +183,8 @@ describe('Promises support', function () {
       it('should work on request fail', function (done) {
         makeRequest(customPromiseFactory, done, true)
           .catch(function (err) {
-            t.strictEqual(err, 'Internal Server Error');
+            t.strictEqual(err.statusCode, 500);
+            t.strictEqual(err.error, 'Internal Server Error');
             done();
           });
       });
@@ -203,7 +207,8 @@ describe('Promises support', function () {
       it('should work on request fail', function (done) {
         makeRequest(customPromiseFactory, done, true)
           .fail(function (err) {
-            t.strictEqual(err, 'Internal Server Error');
+            t.strictEqual(err.statusCode, 500);
+            t.strictEqual(err.error, 'Internal Server Error');
             done();
           });
       });
@@ -223,7 +228,8 @@ describe('Promises support', function () {
       it('should work on request fail', function (done) {
         makeRequest(customPromiseFactory, done, true)
           .catch(function (err) {
-            t.strictEqual(err, 'Internal Server Error');
+            t.strictEqual(err.statusCode, 500);
+            t.strictEqual(err.error, 'Internal Server Error');
             done();
           });
       });


### PR DESCRIPTION
Rejects the promise with [`StatusCodeError`](https://github.com/request/promise-core/blob/master/lib/errors.js#L22) from [request/promise-core](https://github.com/request/promise-core) when the response status is 4XX or 5XX. This change aligns node-request-retry with current [request/request-promise](https://github.com/request/request-promise) behaviour.