### PR TITLE
add ability to override request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,16 @@ request({
 });
 ```
 
-## How to extend the default request
+## How to access the underlying request library
+
+You can access to the underlying `request` library thanks to `request.Request`:
+
+```javascript
+const request = require('requestretry');
+console.log(request.Request); // original request library
+```
+
+Thus, if needed, it's possible to monkey-patch or extend the underlying Request library:
 
 ```javascript
 request.Request = class extends request.Request {

--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ request({
 });
 ```
 
+## How to extend the default request
+
+```javascript
+request.Request = class extends request.Request {
+  constructor(url, options, f, retryConfig) {
+    super(url, options, f, retryConfig);
+    // this constructor will be called for every requestretry call,
+    // and give you global logging
+    console.log('Request', url, options, f, retryConfig);
+  }
+}
+```
+
+
 ## Modifying `request` options
 
 You can use the `defaults` method to provide default options like so:

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ Request.prototype.abort = function () {
 
 function Factory(url, options, f) {
   var retryConfig = _.chain(_.isObject(url) ? url : options || {}).defaults(DEFAULTS).pick(Object.keys(DEFAULTS)).value();
-  var req = new Request(url, options, f, retryConfig);
+  var req = new Factory.Request(url, options, f, retryConfig);
   req._tryUntilFail();
   return req;
 }

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var request = require('../');
+var t = require('chai').assert;
+
+describe('Request', function () {
+  it('should use overridden Request', function (done) {
+    var set = false;
+    request.Request = class extends request.Request {
+      constructor(url, options, f, retryConfig) {
+        super(url, options, f, retryConfig);
+        set = true;
+      }
+    };
+    request('http://www.filltext.com/?rows=1', function (err, response, body) {
+      t.strictEqual(set, true);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
I want to add a global logger to requestretry similar to request-debug. However request-debug takes advantage of the fact that there is an [init method on the prototype that it can hook](https://github.com/request/request-debug/blob/master/index.js#L25) to get access to the request the moment it is created. Given that this library has no init method to hook into, I could alternatively subclass request.Request and add my hooks in the constructor, provided the Request set on the factory was the one actually used. If there is a different approach to do the same thing I'd be happy to give that a try.