### PR TITLE
Also retry on HTTP Status 429 "Too Many Requests"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![NPM](https://nodei.co/npm/requestretry.png?downloadRank=true) ![NPM](https://nodei.co/npm-dl/requestretry.png?months=3&height=2)
 
-When the connection fails with one of `ECONNRESET`, `ENOTFOUND`, `ESOCKETTIMEDOUT`, `ETIMEDOUT`, `ECONNREFUSED`, `EHOSTUNREACH`, `EPIPE`, `EAI_AGAIN` or when an HTTP 5xx error occurrs, the request will automatically be re-attempted as these are often recoverable errors and will go away on retry.
+When the connection fails with one of `ECONNRESET`, `ENOTFOUND`, `ESOCKETTIMEDOUT`, `ETIMEDOUT`, `ECONNREFUSED`, `EHOSTUNREACH`, `EPIPE`, `EAI_AGAIN` or when an HTTP 5xx or 429 error occurrs, the request will automatically be re-attempted as these are often recoverable errors and will go away on retry.
 
 
 > ## ❤️ Shameless plug

--- a/strategies/HTTPError.js
+++ b/strategies/HTTPError.js
@@ -6,5 +6,12 @@
  * @return {Boolean} true if the request had a recoverable HTTP error
  */
 module.exports = function HTTPError(err, response) {
-  return response && 500 <= response.statusCode && response.statusCode < 600;
+  let statusCode;
+
+  if (response) {
+    statusCode = response.statusCode
+  }
+
+  // 429 means "Too Many Requests" while 5xx means "Server Error"
+  return statusCode && (statusCode === 429 || (500 <= statusCode && statusCode < 600));
 };

--- a/test/strategies.test.js
+++ b/test/strategies.test.js
@@ -39,7 +39,7 @@ function checkHTTPErrors(strategy) {
     }), code + ' error is not recoverable');
   });
 
-  [500, 599].forEach(function (code) {
+  [429, 500, 599].forEach(function (code) {
     t.ok(strategy(null, {
       statusCode: code
     }), code + ' error is recoverable');


### PR DESCRIPTION
API providers may return an HTTP status code of 429 to mean "Too Many
Requests".

By setting a custom retry policy, this module can be used to wait
until the throttling period has expired and try again.

Reference: https://httpstatuses.com/429