### PR TITLE
Add support for simple promise rejection.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,8 +109,15 @@ function Request(url, options, f, retryConfig) {
       return this._reject(err);
     }
 
+    var statusCode = response.statusCode;
+
     // resolve with the full response or just the body
     response = this.fullResponse ? response : body;
+
+    if (this.options.simple && statusCode >= 300) {
+      return this._reject(response);
+    }
+
     this._resolve(response);
   };
 }

--- a/test/promises.test.js
+++ b/test/promises.test.js
@@ -92,6 +92,42 @@ describe('Promises support', function () {
     });
   });
 
+  it('should resolve 2xx responses when running in simple mode', function (done) {
+    request({
+      url: 'http://www.filltext.com/?rows=1', // return 1 row of data
+      simple: true
+    })
+      .then(function (response) {
+        t.strictEqual(response.statusCode, 200);
+        t.strictEqual(response.attempts, 1);
+        done();
+      });
+  });
+
+  it('should reject 4xx errors when running in simple mode', function (done) {
+    request({
+      url: 'http://www.filltext.com/?rows=1&err=400', // return a 400 status
+      maxAttempts: 1,
+      simple: true
+    }).catch(function (err) {
+      t.strictEqual(err.statusCode, 400);
+      t.strictEqual(err.body, 'Bad Request');
+      done();
+    });
+  });
+
+  it('should reject 5xx errors when running in simple mode', function (done) {
+    request({
+      url: 'http://www.filltext.com/?rows=1&err=500', // return a 500 status
+      maxAttempts: 1,
+      simple: true
+    }).catch(function (err) {
+      t.strictEqual(err.statusCode, 500);
+      t.strictEqual(err.body, 'Internal Server Error');
+      done();
+    });
+  });
+
   describe('Different libraries support', function () {
 
     function makeRequest(promiseFactoryFn, done, throwError) {


### PR DESCRIPTION
Similar to request-promise, we could add a `simple` option which causes all responses with statuscode > 2xx to be rejected. 