### PR TITLE
Add onResponse hook to options block

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,10 @@ Request.prototype._tryUntilFail = function () {
   this.attempts++;
 
   this._req = Request.request(this.options, function (err, response, body) {
+    if (this.options.onResponse) {
+      this.options.onResponse(this, err, response, body);
+    }
+
     if (response) {
       response.attempts = this.attempts;
     }

--- a/test/attempts.test.js
+++ b/test/attempts.test.js
@@ -13,6 +13,23 @@ describe('Request attempts', function () {
     });
   });
 
+  it('should fire onResponse method for each attempt', function (done) {
+    request({
+      url: 'http://www.filltext.com/?rows=1&err=500', // returns a 500 status
+      maxAttempts: 3,
+      retryDelay: 100,
+      onResponse: (request, err, response, body) => {
+        request.onResponseCount = !request.onResponseCount ? 1 : request.onResponseCount + 1;
+        response.onResponseCount = request.onResponseCount;
+      }
+    }, function(err, response, body) {
+      if(err) done(err);
+      t.strictEqual(3, response.attempts);
+      t.strictEqual(3, response.onResponseCount);
+      done();
+    });
+  });
+
   it('should show 3 attempts after some retries', function (done) {
     request({
       url: 'http://www.filltext.com/?rows=1&err=500', // return a 500 status


### PR DESCRIPTION
Monkey patching for logging has been problematic for us based on other things going on with load timings, other monkey patching activity on request, etc.  This hook will allow us to do arbitrary logging in a really obvious way.  It's likely useful for other bits as well.