### PR TITLE
fix: remove dependency on when in favor of native Promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@
  *
  */
 var extend = require('extend');
-var when = require('when');
 var request = require('request');
 var RetryStrategies = require('./strategies');
 var _ = require('lodash');
@@ -22,7 +21,7 @@ var DEFAULTS = {
 
 // Default promise factory which use bluebird
 function defaultPromiseFactory(resolver) {
-  return when.promise(resolver);
+  return new Promise(resolver);
 }
 
 function _cloneOptions(options) {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "extend": "^3.0.2",
-    "lodash": "^4.17.15",
-    "when": "^3.7.7"
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "request": "2.*.*"


### PR DESCRIPTION
when is a peculiar library that cannot be bundled by tools like esbuild. Additionally, Promise implementations are available in all currently supported Node releases, so we can remove this dependency without impacting user ability to override `promiseFactory`.

This should fix https://github.com/snowflakedb/snowflake-connector-nodejs/issues/146 and allow other consumers of requestretry to bundle it with esbuild, too.