### PR TITLE
should not remove authorization/cookie when no redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function sanitizeHeaders(options) {
     const qUrl = url.parse(queryObject[queryParam]);
 
     // external link if protocol || host || port is different
-    return (qUrl.protocol !== urlObject.protocol || qUrl.host !== urlObject.host || qUrl.port !== urlObject.port);
+    return (!!qUrl.host && ( qUrl.protocol !== urlObject.protocol || qUrl.host !== urlObject.host || qUrl.port !== urlObject.port) );
   });
 
   if (hasExternalLink && options.hasOwnProperty("headers") && typeof (options.headers) === "object") {

--- a/test/leak.test.js
+++ b/test/leak.test.js
@@ -5,23 +5,23 @@ var t = require('chai').assert;
 
 describe('Information Leak', function () {
 
-    it('should not forward cookie headers when the request has a redirect from another protocol/domain/port', function (done) {
+  it('should not forward cookie headers when the request has a redirect from another protocol/domain/port', function (done) {
 
-        request({
-            url: 'https://httpbingo.org/redirect-to?url=http://httpbingo.org/cookies',
-            headers: {
-                'Content-Type': 'application/json',
-                'cookie': 'ajs_anonymous_id=1234567890',
-                'authorization': 'Bearer eyJhb12345abcdef'
-            },
-            json:true
-        }, function (err, response, body) {
-            t.deepEqual(Object.keys(body).length, 0);
-            done();
-        });
-    });
+      request({
+          url: 'https://httpbingo.org/redirect-to?url=http://httpbingo.org/cookies',
+          headers: {
+              'Content-Type': 'application/json',
+              'cookie': 'ajs_anonymous_id=1234567890',
+              'authorization': 'Bearer eyJhb12345abcdef'
+          },
+          json:true
+      }, function (err, response, body) {
+          t.deepEqual(Object.keys(body).length, 0);
+          done();
+      });
+  });
 
-  it('should  forward cookie headers when the request has a redirect from the same protocol/domain/port', function (done) {
+  it('should forward cookie headers when the request has a redirect from the same protocol/domain/port', function (done) {
 
     request({
       url: 'https://httpbingo.org/redirect-to?url=https://httpbingo.org/cookies',
@@ -39,25 +39,61 @@ describe('Information Leak', function () {
     });
   });
 
-    it('should not forward authorization headers when the request has a redirect', function (done) {
+  it('should forward cookie headers when the request hasn\'t any redirect', function (done) {
 
-        request({
-            url: 'https://httpbingo.org/redirect-to?url=http://httpbingo.org/bearer',
-            headers: {
-                'Content-Type': 'application/json',
-                'cookie': 'ajs_anonymous_id=1234567890',
-                'authorization': 'Bearer eyJhb12345abcdef'
-            }
-        }, function (err, response, body) {
-            t.deepEqual(body, undefined);
-            done();
-        });
+    request({
+      url: 'https://httpbingo.org/cookies?test=hello',
+      headers: {
+        'Content-Type': 'application/json',
+        'cookie': 'ajs_anonymous_id=1234567890',
+        'authorization': 'Bearer eyJhb12345abcdef'
+      },
+      json:true
+    }, function (err, response, body) {
+      t.deepEqual(body, {
+        "ajs_anonymous_id": "1234567890"
+      });
+      done();
     });
+  });
+
+  it('should not forward authorization headers when the request has a redirect', function (done) {
+
+      request({
+          url: 'https://httpbingo.org/redirect-to?url=http://httpbingo.org/bearer',
+          headers: {
+              'Content-Type': 'application/json',
+              'cookie': 'ajs_anonymous_id=1234567890',
+              'authorization': 'Bearer eyJhb12345abcdef'
+          }
+      }, function (err, response, body) {
+          t.deepEqual(body, undefined);
+          done();
+      });
+  });
 
   it('should forward authorization headers when the request has a redirect from the same protocol/domain/port', function (done) {
 
     request({
       url: 'https://httpbingo.org/redirect-to?url=https://httpbingo.org/bearer',
+      headers: {
+        'Content-Type': 'application/json',
+        'cookie': 'ajs_anonymous_id=1234567890',
+        'authorization': 'Bearer eyJhb12345abcdef'
+      }
+    }, function (err, response, body) {
+      t.deepEqual(body, {
+        "authenticated": true,
+        "token": "eyJhb12345abcdef"
+      });
+      done();
+    });
+  });
+
+  it('should forward authorization headers when the request hasn\'t any redirect', function (done) {
+
+    request({
+      url: 'https://httpbingo.org/bearer?test=hello',
       headers: {
         'Content-Type': 'application/json',
         'cookie': 'ajs_anonymous_id=1234567890',


### PR DESCRIPTION
Corrected the sanitizeHeaders function and added two more tests.

```txt
Information Leak
    ✔ should forward cookie headers when the request hasn't any redirect (598ms)
    ✔ should forward authorization headers when the request hasn't any redirect (523ms)
```