### PR TITLE
Handle request with a url with query param that contains a character that can't be parsed by url.parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,14 @@ function sanitizeHeaders(options) {
   const hasExternalLink = Object.keys(queryObject).some(function (queryParam) {
     const values = _.isArray(queryObject[queryParam]) ? queryObject[queryParam] : [queryObject[queryParam]]
     return values.map(v => {
-      const qUrl = url.parse(v);
+      try {
+        const qUrl = url.parse(v);
 
-      // external link if protocol || host || port is different
-      return (!!qUrl.host && ( qUrl.protocol !== urlObject.protocol || qUrl.host !== urlObject.host || qUrl.port !== urlObject.port) );
+        // external link if protocol || host || port is different
+        return (!!qUrl.host && ( qUrl.protocol !== urlObject.protocol || qUrl.host !== urlObject.host || qUrl.port !== urlObject.port) );
+      } catch (ex) {
+        return false;
+      }
     }).some(v => v === true)
   });
 

--- a/test/urls.test.js
+++ b/test/urls.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var request = require('../');
+var t = require('chai').assert;
+var sinon = require('sinon');
+
+describe('URLs', function () {
+  it('should handle a request with a query param containing encoded characters that don\'t parse into a url', function (done) {
+    // 12:30PM with NARROW NO-BREAK SPACE between 0 and P
+    request.get('http://www.filltext.com/?q=12%3A30%E2%80%AFPM', function (err, response, body) {
+      t.strictEqual(response.statusCode, 200);
+      t.strictEqual(response.attempts, 1);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
With this query param `q=12:30 PM` (NARROW NO-BREAK SPACE between 0 and P), url.parse throws, but there is no need for requestretry to error out while checking for external links in query params.